### PR TITLE
Behroozi 2019 SMHM data (fit for all z)

### DIFF
--- a/velociraptor/fitting_formulae/smhmr.py
+++ b/velociraptor/fitting_formulae/smhmr.py
@@ -184,41 +184,35 @@ def behroozi_2019_raw(z, Mhalo):
 
     Mhalo_log = np.log10(Mhalo)
 
-    param_list = [
-        -1.430476,
-        1.795813,
-        1.359576,
-        -0.2156067,
-        12.04003,
-        4.675185,
-        4.513113,
-        -0.7444014,
-        1.973063,
-        -2.3534,
-        -1.783277,
-        0.1860354,
-        0.4732459,
-        -0.8842523,
-        -0.486104,
-        0.4067526,
-        -1.087851,
-        -3.241419,
-        -1.078538,
-        1.149615e02,
-    ]
-
-    names = (
-        "EFF_0 EFF_0_A EFF_0_A2 EFF_0_Z M_1 M_1_A M_1_A2 M_1_Z ALPHA ALPHA_A "
-        "ALPHA_A2 ALPHA_Z BETA BETA_A BETA_Z DELTA GAMMA GAMMA_A GAMMA_Z CHI2".split(
-            " "
-        )
-    )
-    params = dict(zip(names, param_list))
+    params = {
+        "EFF_0": -1.430476,
+        "EFF_0_A": 1.795813,
+        "EFF_0_A2": 1.359576,
+        "EFF_0_Z": -0.2156067,
+        "M_1": 12.04003,
+        "M_1_A": 4.675185,
+        "M_1_A2": 4.513113,
+        "M_1_Z": -0.7444014,
+        "ALPHA": 1.973063,
+        "ALPHA_A": -2.3534,
+        "ALPHA_A2": -1.783277,
+        "ALPHA_Z": 0.1860354,
+        "BETA": 0.4732459,
+        "BETA_A": -0.8842523,
+        "BETA_Z": -0.486104,
+        "DELTA": 0.4067526,
+        "GAMMA": -1.087851,
+        "GAMMA_A": -3.241419,
+        "GAMMA_Z": -1.078538,
+        "CHI2": 1.149615e02,
+    }
 
     a = 1.0 / (1.0 + z)
     a1 = a - 1.0
     lna = np.log(a)
+
     zparams = {}
+
     zparams["m_1"] = (
         params["M_1"]
         + a1 * params["M_1_A"]
@@ -252,4 +246,4 @@ def behroozi_2019_raw(z, Mhalo):
         + zparams["gamma"] * np.exp(-0.5 * (dm2 * dm2))
     )
 
-    return 10. ** logmstar
+    return 10.0 ** logmstar

--- a/velociraptor/fitting_formulae/smhmr.py
+++ b/velociraptor/fitting_formulae/smhmr.py
@@ -174,8 +174,10 @@ def behroozi_2019_raw(z, Mhalo):
     This function is a median fit to the raw data for centrals (i.e. excluding
     satellites)
 
-    The stellar mass is the true stellar mass (i.e. w/o observational corrections and
-    excluding intrahalo light)
+    The stellar mass is the true stellar mass (i.e. w/o observational corrections)
+
+    The fitting function does not include the intrahalo light contribution to the
+    stellar mass
 
     The halo mass is the peak halo mass that follows the Bryan & Norman (1998)
     spherical overdensity definition

--- a/velociraptor/fitting_formulae/smhmr.py
+++ b/velociraptor/fitting_formulae/smhmr.py
@@ -171,9 +171,11 @@ def behroozi_2019_raw(z, Mhalo):
 
     The data is taken from https://www.peterbehroozi.com/data.html
 
-    This function is a median fit to the raw data for centrals (i.e. excluding satellites)
+    This function is a median fit to the raw data for centrals (i.e. excluding
+    satellites)
 
-    The stellar mass is the true stellar mass (i.e. w/o observational corrections)
+    The stellar mass is the true stellar mass (i.e. w/o observational corrections and
+    excluding intrahalo light)
 
     The halo mass is the peak halo mass that follows the Bryan & Norman (1998)
     spherical overdensity definition

--- a/velociraptor/fitting_formulae/smhmr.py
+++ b/velociraptor/fitting_formulae/smhmr.py
@@ -171,8 +171,7 @@ def behroozi_2019_raw(z, Mhalo):
 
     The data is taken from https://www.peterbehroozi.com/data.html
 
-    This function is a Median Fit to the raw data including both satellites and
-    centrals.
+    This function is a median fit to the raw data for centrals (i.e. excluding satellites)
 
     The stellar mass is the true stellar mass (i.e. w/o observational corrections)
 
@@ -185,26 +184,25 @@ def behroozi_2019_raw(z, Mhalo):
     Mhalo_log = np.log10(Mhalo)
 
     params = {
-        "EFF_0": -1.430476,
-        "EFF_0_A": 1.795813,
-        "EFF_0_A2": 1.359576,
-        "EFF_0_Z": -0.2156067,
-        "M_1": 12.04003,
-        "M_1_A": 4.675185,
-        "M_1_A2": 4.513113,
-        "M_1_Z": -0.7444014,
-        "ALPHA": 1.973063,
-        "ALPHA_A": -2.3534,
-        "ALPHA_A2": -1.783277,
-        "ALPHA_Z": 0.1860354,
-        "BETA": 0.4732459,
-        "BETA_A": -0.8842523,
-        "BETA_Z": -0.486104,
-        "DELTA": 0.4067526,
-        "GAMMA": -1.087851,
-        "GAMMA_A": -3.241419,
-        "GAMMA_Z": -1.078538,
-        "CHI2": 1.149615e02,
+        "EFF_0": -1.431495,
+        "EFF_0_A": 1.75703,
+        "EFF_0_A2": 1.350451,
+        "EFF_0_Z": -0.217846,
+        "M_1": 12.07402,
+        "M_1_A": 4.599896,
+        "M_1_A2": 4.423389,
+        "M_1_Z": -0.7324986,
+        "ALPHA": 1.973839,
+        "ALPHA_A": -2.468417,
+        "ALPHA_A2": -1.816299,
+        "ALPHA_Z": 0.18208,
+        "BETA": 0.4702271,
+        "BETA_A": -0.8751643,
+        "BETA_Z": -0.486642,
+        "DELTA": 0.3822958,
+        "GAMMA": -1.160189,
+        "GAMMA_A": -3.633671,
+        "GAMMA_Z": -1.2189,
     }
 
     a = 1.0 / (1.0 + z)

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -570,7 +570,7 @@ class ObservationalData(object):
             kwargs["zorder"] = line_zorder
 
         # Make both the data name and redshift appear in the legend
-        data_label = self.citation + " ($z={:.1f}$)".format(self.redshift)
+        data_label = f"{self.citation} ($z={self.redshift:.1f}$)"
 
         axes.errorbar(
             self.x,

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -539,7 +539,7 @@ class ObservationalData(object):
         else:
             kwargs = {}
 
-        # Ensure correct units throughout, in case somebody chagned them
+        # Ensure correct units throughout, in case somebody changed them
         if self.x_scatter is not None:
             self.x_scatter.convert_to_units(self.x.units)
 
@@ -569,13 +569,16 @@ class ObservationalData(object):
         elif self.plot_as == "line":
             kwargs["zorder"] = line_zorder
 
+        # Make both the data name and redshift appear in the legend
+        data_label = self.citation + " ($z={:.1f}$)".format(self.redshift)
+
         axes.errorbar(
             self.x,
             self.y,
             yerr=self.y_scatter,
             xerr=self.x_scatter,
             **kwargs,
-            label=self.citation
+            label=data_label
         )
 
         return


### PR DESCRIPTION
- Behroozi 2019 SMHM fitting function (for all z) has been added to VR
- Redshifts will now show up in obs-data curves' labels

Example of the new stellar mass halo mass plot:

![stellar_mass_halo_mass_centrals_30](https://user-images.githubusercontent.com/20153933/95665009-ba8aa300-0b4c-11eb-9b1a-d3e7ec7e6c5c.png)
