### PR TITLE
Handle Type & Value error for z from ObsData catalogue

### DIFF
--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -571,7 +571,7 @@ class ObservationalData(object):
 
         try:
             # Make both the data name and redshift appear in the legend
-            data_label = f"{self.citation} ($z={self.redshift:.cd ;1f}$)"
+            data_label = f"{self.citation} ($z={self.redshift:.1f}$)"
         except (TypeError, ValueError):
             data_label = self.citation
 
@@ -581,7 +581,7 @@ class ObservationalData(object):
             yerr=self.y_scatter,
             xerr=self.x_scatter,
             **kwargs,
-            label=data_label
+            label=data_label,
         )
 
         return

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -476,6 +476,12 @@ class ObservationalData(object):
 
         """
 
+        try:
+            fake_axis_label = f"{redshift:.1f}"
+        except (TypeError, ValueError) as Error:
+            print(f"Redshift must be a float, not {redshift} \n")
+            raise Error
+
         self.redshift = redshift
 
         return
@@ -569,11 +575,8 @@ class ObservationalData(object):
         elif self.plot_as == "line":
             kwargs["zorder"] = line_zorder
 
-        try:
-            # Make both the data name and redshift appear in the legend
-            data_label = f"{self.citation} ($z={self.redshift:.1f}$)"
-        except (TypeError, ValueError):
-            data_label = self.citation
+        # Make both the data name and redshift appear in the legend
+        data_label = f"{self.citation} ($z={self.redshift:.1f}$)"
 
         axes.errorbar(
             self.x,

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -569,8 +569,11 @@ class ObservationalData(object):
         elif self.plot_as == "line":
             kwargs["zorder"] = line_zorder
 
-        # Make both the data name and redshift appear in the legend
-        data_label = f"{self.citation} ($z={self.redshift:.1f}$)"
+        try:
+            # Make both the data name and redshift appear in the legend
+            data_label = f"{self.citation} ($z={self.redshift:.cd ;1f}$)"
+        except (TypeError, ValueError):
+            data_label = self.citation
 
         axes.errorbar(
             self.x,


### PR DESCRIPTION
I was doing some tests with the pipeline and unexpectedly got a **TypeError** in the file

```
File "../pipeline-configs/colibre//scripts/bh_accretion_evolution.py", line 87, in <module>
    obs.plot_on_axes(ax)
File "/home/evgenii/velociraptor-python/velociraptor/observations/objects.py", line 573, in plot_on_axes
   data_label = f"{self.citation} ($z={self.redshift:.1f}$)"
```

That is because in  [this observational-data conversion script](https://github.com/SWIFTSIM/velociraptor-comparison-data/blob/c5b5c1a3c4be6878fe74f22d62578040158bbb52/data/BlackHoleAccretionHistory/conversion/convertAird2015.py), a **NumPy array** is stored in **metadata.redshift** field instead of a float number.

This case can be correctly handled with the change I introduced in this PR. In addition to **TypeError** I described above, I also included **ValueError** in case somebody decides to store an empty string in **metadata.redshift** field, or something like that.

