### PR TITLE
make units consistent in the case of no data

### DIFF
--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -350,8 +350,8 @@ class VelociraptorLine(object):
                     up = errors
                     down = errors
             else:
-                up = 0
-                down = 0
+                up = unyt_quantity(0, units=heights.units)
+                down = unyt_quantity(0, units=heights.units)
 
             ax.fill_between(
                 centers,


### PR DESCRIPTION
A tiny fix to the case whereby a plot has no data. Without this fix, in the no-data case, we may be adding quantities that have dimensions with dimensionless quantities (see the lines of code I changed to understand exactly what I mean). This makes `unyt` library unhappy.

With the fix, plots like the one below are correctly made:

![H2_mass_star_formation_rate_100](https://user-images.githubusercontent.com/20153933/101777725-2eb4d900-3af3-11eb-83e5-03c0d7a86670.png)


