### PR TITLE
Bug in plots with adaptive binning

### DIFF
--- a/velociraptor/tools/adaptive.py
+++ b/velociraptor/tools/adaptive.py
@@ -190,11 +190,18 @@ def create_adaptive_bins(
             number_in_bin.append(current_bin_count)
         elif current_bin_count == 1:
             # Extend the previous bin (otherwise error is consistent with zero)
-            bin_edges_right[-1] = value
-            number_in_bin[-1] += 1
-            bin_medians[-1] = np.median(sorted_values[-number_in_bin[-1] :])
-            # We don't need the next bin now.
-            bin_edges_left = bin_edges_left[:-1]
+            try:
+                bin_edges_right[-1] = value
+                number_in_bin[-1] += 1
+                bin_medians[-1] = np.median(sorted_values[-number_in_bin[-1]:])
+                # We don't need the next bin now.
+                bin_edges_left = bin_edges_left[:-1]
+
+            # There is no previous bin because we have just one bin in total
+            except IndexError:
+                bin_edges_right.append(value)
+                number_in_bin.append(1)
+                bin_medians.append(sorted_values[-1])
         else:
             # This bin doesn't exist anyway, boo...
             bin_edges_left = bin_edges_left[:-1]

--- a/velociraptor/tools/mass_functions.py
+++ b/velociraptor/tools/mass_functions.py
@@ -272,11 +272,18 @@ def create_adaptive_mass_function(
         number_in_bin.append(current_bin_count)
     elif current_bin_count == 1:
         # Extend the previous bin (otherwise error is consistent with zero)
-        bin_edges_right[-1] = mass
-        number_in_bin[-1] += 1
-        bin_medians[-1] = np.median(sorted_masses[-number_in_bin[-1] :])
-        # We don't need the next bin now.
-        bin_edges_left = bin_edges_left[:-1]
+        try:
+            bin_edges_right[-1] = mass
+            number_in_bin[-1] += 1
+            bin_medians[-1] = np.median(sorted_masses[-number_in_bin[-1] :])
+            # We don't need the next bin now.
+            bin_edges_left = bin_edges_left[:-1]
+
+        # There is no previous bin because we have just one bin in total
+        except IndexError:
+            bin_edges_right.append(mass)
+            number_in_bin.append(1)
+            bin_medians.append(sorted_masses[-1])
     else:
         # This bin doesn't exist anyway, boo...
         bin_edges_left = bin_edges_left[:-1]


### PR DESCRIPTION
Hi @JBorrow, I've found one more bug.

This one is particularly annoying because it makes the whole pipeline crash, not just one plot.

**Explanation**
The bug occurs in the plots with `adaptive binning` in the case that we want to **stretch** the previous bin to cover the remaining data points. The latter will err if we have just one bin in total (i.e. in this case there's no previous bin because the total number of bins is one)

**Backtrace**

```
Traceback (most recent call last):
  File "/home/evgenii/anaconda3/bin/swift-pipeline", line 241, in <module>
    directory=args.output, file_extension=PLOT_FILE_EXTENSION, debug=args.debug
  File "/home/evgenii/velociraptor-python/velociraptor/autoplotter/objects.py", line 1026, in create_plots
    file_extension=file_extension,
  File "/home/evgenii/velociraptor-python/velociraptor/autoplotter/objects.py", line 868, in make_plot
    fig, ax = getattr(self, f"_make_plot_{self.plot_type}")(catalogue=catalogue)
  File "/home/evgenii/velociraptor-python/velociraptor/autoplotter/objects.py", line 788, in _make_plot_adaptivemassfunction
    return self._make_plot_massfunction(catalogue=catalogue)
  File "/home/evgenii/velociraptor-python/velociraptor/autoplotter/objects.py", line 768, in _make_plot_massfunction
    x=x, y=None, box_volume=catalogue.units.comoving_box_volume
  File "/home/evgenii/velociraptor-python/velociraptor/autoplotter/lines.py", line 215, in create_line
    self.generate_bins(values=x)
  File "/home/evgenii/velociraptor-python/velociraptor/autoplotter/lines.py", line 151, in generate_bins
    stretch_final_bin="mass_function" in self.line_type,
  File "/home/evgenii/velociraptor-python/velociraptor/tools/adaptive.py", line 198, in create_adaptive_bins
    bin_edges_right[-1] = value
IndexError: list assignment index out of range
```

P.S. I had to fix this bug in two different files. The latter makes me wonder - why do we have the same code in two different files (with the only difference being that `mass` is replaced by `value`)?