### PR TITLE
Highlight additional points in single-run plots

### DIFF
--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -326,14 +326,12 @@ class VelociraptorLine(object):
             x=x, y=y
         )
 
-        color_name = "C0"
-
         if self.scatter == "none" or errors is None:
-            ax.plot(centers, heights, label=label, color=color_name)
+            (line,) = ax.plot(centers, heights, label=label)
         elif self.scatter == "errorbar":
-            ax.errorbar(centers, heights, yerr=errors, label=label, color=color_name)
+            (line, *_) = ax.errorbar(centers, heights, yerr=errors, label=label)
         elif self.scatter == "errorbar_both":
-            ax.errorbar(
+            (line, *_) = ax.errorbar(
                 centers,
                 heights,
                 yerr=errors,
@@ -343,7 +341,7 @@ class VelociraptorLine(object):
                 fmt=".",  # Do not plot as a line.
             )
         elif self.scatter == "shaded":
-            ax.plot(centers, heights, label=label, color=color_name)
+            (line,) = ax.plot(centers, heights, label=label)
 
             # Deal with different + and -ve errors
             if errors.shape[0]:
@@ -360,11 +358,14 @@ class VelociraptorLine(object):
                 centers,
                 heights - down,
                 heights + up,
-                color=color_name,
+                color=line.get_color(),
                 alpha=0.3,
                 linewidth=0.0,
             )
 
-        ax.scatter(additional_x.value, additional_y.value, color=color_name)
+        try:
+            ax.scatter(additional_x.value, additional_y.value, color=line.get_color())
+        except NameError:
+            ax.scatter(additional_x.value, additional_y.value, color="C0")
 
         return

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -326,10 +326,12 @@ class VelociraptorLine(object):
             x=x, y=y
         )
 
+        color_name = "C0"
+
         if self.scatter == "none" or errors is None:
-            ax.plot(centers, heights, label=label)
+            ax.plot(centers, heights, label=label, color=color_name)
         elif self.scatter == "errorbar":
-            ax.errorbar(centers, heights, yerr=errors, label=label)
+            ax.errorbar(centers, heights, yerr=errors, label=label, color=color_name)
         elif self.scatter == "errorbar_both":
             ax.errorbar(
                 centers,
@@ -337,10 +339,11 @@ class VelociraptorLine(object):
                 yerr=errors,
                 xerr=abs(self.bins - centers),
                 label=label,
+                color=color_name,
                 fmt=".",  # Do not plot as a line.
             )
         elif self.scatter == "shaded":
-            (line,) = ax.plot(centers, heights, label=label)
+            ax.plot(centers, heights, label=label, color=color_name)
 
             # Deal with different + and -ve errors
             if errors.shape[0]:
@@ -357,9 +360,11 @@ class VelociraptorLine(object):
                 centers,
                 heights - down,
                 heights + up,
-                color=line.get_color(),
+                color=color_name,
                 alpha=0.3,
                 linewidth=0.0,
             )
+
+        ax.scatter(additional_x.value, additional_y.value, color=color_name)
 
         return

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -364,7 +364,8 @@ class VelociraptorLine(object):
 
         try:
             ax.scatter(additional_x.value, additional_y.value, color=line.get_color())
+        # In case the line object is undefined
         except NameError:
-            ax.scatter(additional_x.value, additional_y.value, color="C0")
+            ax.scatter(additional_x.value, additional_y.value)
 
         return

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -337,7 +337,6 @@ class VelociraptorLine(object):
                 yerr=errors,
                 xerr=abs(self.bins - centers),
                 label=label,
-                color=color_name,
                 fmt=".",  # Do not plot as a line.
             )
         elif self.scatter == "shaded":


### PR DESCRIPTION
We have decided to highlight the additional data points in single-run plots; otherwise, they could be not visible because of the observational data plotted above

**Result:** [LINK](http://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/DEC2020/L006N188/NO_EOS/z0.0_2E51_FKIN03_VKICK050_BOOST01/)
