### PR TITLE
Show arrows where the data is outside the plot's domain

### DIFF
--- a/velociraptor/autoplotter/compare.py
+++ b/velociraptor/autoplotter/compare.py
@@ -44,14 +44,14 @@ def load_yaml_line_data(
     ----------
     paths: Union[str, List[str]]
         Paths to yaml data files to load.
-    
+
     names: Union[str, List[str]]
         Names of the simulations that correspond to the yaml data files.
         Will be placed in the legends of the plots.
-        
+
     Returns
     -------
-    
+
     data: Dict[str, Dict]
         Dictionary of line data read directly from the files.
     """
@@ -139,7 +139,7 @@ def recreate_single_figure(
     """
     Recreates a single figure using the data in ``line_data`` and the metadata in
     ``plot``.
-    
+
     Parameters
     ----------
     plot: VelociraptorPlot
@@ -229,6 +229,19 @@ def recreate_single_figure(
                     ax.plot(centers, heights, label=name)
 
                 ax.scatter(additional_x, additional_y, c=color_name)
+
+                # Enter only if the plot has a valid Y-axis range and there are any
+                # additional data points.
+                if plot.y_lim is not None and len(additional_x) > 0:
+
+                    # Add arrows to the plot for each data point beyond the Y-axis range
+                    line.highlight_data_outside_domain(
+                        ax,
+                        additional_x.value,
+                        additional_y.value,
+                        color_name,
+                        (plot.y_lim[0].value, plot.y_lim[1].value),
+                    )
 
     # Add observational data second to allow for colour precedence
     # to go to runs

--- a/velociraptor/autoplotter/compare.py
+++ b/velociraptor/autoplotter/compare.py
@@ -234,12 +234,13 @@ def recreate_single_figure(
                 # additional data points.
                 if plot.y_lim is not None and len(additional_x) > 0:
 
-                    # Add arrows to the plot for each data point beyond the Y-axis range
+                    # Draw arrows for each data point beyond X- or/and Y- axis range
                     line.highlight_data_outside_domain(
                         ax,
                         additional_x.value,
                         additional_y.value,
                         color_name,
+                        (plot.x_lim[0].value, plot.x_lim[1].value),
                         (plot.y_lim[0].value, plot.y_lim[1].value),
                     )
 

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -3,7 +3,7 @@ Objects for handling and plotting mean and median lines.
 """
 
 from unyt import unyt_quantity, unyt_array
-from numpy import logspace, linspace, log10, logical_and, isnan
+from numpy import logspace, linspace, log10, logical_and, isnan, sqrt
 from typing import Dict, Union, Tuple, List
 from matplotlib.pyplot import Axes
 from matplotlib.transforms import blended_transform_factory
@@ -336,7 +336,7 @@ class VelociraptorLine(object):
         if not isnan(x).any() and not isnan(y).any():
 
             # Arrow parameters
-            arrow_length = 0.14
+            arrow_length = 0.07
             distance_from_edge = 0.01
 
             # Split data into three categories (along X axis)
@@ -371,7 +371,7 @@ class VelociraptorLine(object):
                     textcoords=tform_x,
                     xy=(x_down, distance_from_edge),
                     xycoords=tform_x,
-                    arrowprops=dict(color=color),
+                    arrowprops=dict(color=color, arrowstyle="->"),
                 )
 
             # Draw arrows pointing upwards
@@ -382,7 +382,7 @@ class VelociraptorLine(object):
                     textcoords=tform_x,
                     xy=(x_up, 1.0 - distance_from_edge),
                     xycoords=tform_x,
-                    arrowprops=dict(color=color),
+                    arrowprops=dict(color=color, arrowstyle="->"),
                 )
 
             # Next, find all data points that are outside the X-axis range and
@@ -407,7 +407,7 @@ class VelociraptorLine(object):
                     textcoords=tform_y,
                     xy=(distance_from_edge, y_left),
                     xycoords=tform_y,
-                    arrowprops=dict(color=color),
+                    arrowprops=dict(color=color, arrowstyle="->"),
                 )
 
             # Draw arrows pointing rightwards
@@ -418,7 +418,7 @@ class VelociraptorLine(object):
                     textcoords=tform_y,
                     xy=(1.0 - distance_from_edge, y_right),
                     xycoords=tform_y,
-                    arrowprops=dict(color=color),
+                    arrowprops=dict(color=color, arrowstyle="->"),
                 )
 
             # Finally, handle the points that are both outside the X and Y axis range
@@ -429,19 +429,24 @@ class VelociraptorLine(object):
 
             for x_outside, y_outside in zip(x_outside_list, y_outside_list):
 
+                # Unlike vertical and horizontal arrows, diagonal arrows extend both
+                # in X and Y directions. We account for it by dividing the length of
+                # diagonal arrow along each dimension by \sqrt(2).
+                arrow_proj_length = arrow_length / sqrt(2.0)
+
                 # Find the correct position of the arrow on the plot
                 if x_lim[0] > x_outside:
-                    arrow_start_x = arrow_length + distance_from_edge
+                    arrow_start_x = arrow_proj_length + distance_from_edge
                     arrow_end_x = distance_from_edge
                 else:
-                    arrow_start_x = 1.0 - arrow_length - distance_from_edge
+                    arrow_start_x = 1.0 - arrow_proj_length - distance_from_edge
                     arrow_end_x = 1.0 - distance_from_edge
 
                 if y_lim[0] > y_outside:
-                    arrow_start_y = arrow_length + distance_from_edge
+                    arrow_start_y = arrow_proj_length + distance_from_edge
                     arrow_end_y = distance_from_edge
                 else:
-                    arrow_start_y = 1.0 - arrow_length - distance_from_edge
+                    arrow_start_y = 1.0 - arrow_proj_length - distance_from_edge
                     arrow_end_y = 1.0 - distance_from_edge
 
                 # Use figure's relative coordinates along the X and Y axis.
@@ -453,7 +458,7 @@ class VelociraptorLine(object):
                     textcoords=tform,
                     xy=(arrow_end_x, arrow_end_y),
                     xycoords=tform,
-                    arrowprops=dict(color=color),
+                    arrowprops=dict(color=color, arrowstyle="->"),
                 )
 
         return

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -343,12 +343,12 @@ class VelociraptorLine(object):
             # Split data into three categories (along X axis)
             below_x_range = x < x_lim[0]
             above_x_range = x > x_lim[1]
-            within_x_range = logical_and(x > x_lim[0], x < x_lim[1])
+            within_x_range = logical_and(x >= x_lim[0], x <= x_lim[1])
 
             # Split data into three categories (along Y axis)
             below_y_range = y < y_lim[0]
             above_y_range = y > y_lim[1]
-            within_y_range = logical_and(y > y_lim[0], y < y_lim[1])
+            within_y_range = logical_and(y >= y_lim[0], y <= y_lim[1])
 
             # First, find all data points that are outside the Y-axis range and within
             # X-axis range

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -296,28 +296,48 @@ class VelociraptorLine(object):
         ax: Axes,
         x: unyt_array,
         y: unyt_array,
-        arrow_color: str,
+        color: str,
         y_lim: List,
     ) -> None:
 
         """
-        Add arrows to the plot for each data point residing outside the domain. The
-        arrows indicate where the missing points are. For a given missing data point
-        with its Y(X) coordinate outside the domain, the corresponding arrow will have
-        the same X(Y) coordinate and point to the direction where the missing point is.
+        Add arrows to the plot for each data point residing outside the Y-axis range.
+        The arrows indicate where the missing points are. For a given missing data point
+        with its Y coordinate outside the Y-axis range, the corresponding arrow will
+        have the same X coordinate and point to the direction where the missing point
+        is.
+
+        Parameters
+        ----------
+
+        ax: Axes
+            An object of axes where to draw the arrows
+
+        x: unyt_array
+            Horizontal axis data
+
+        y: unyt_array
+            Vertical axis data
+
+        color: str
+            Color of the arrows that this function will draw. The color should be the
+            same as the color of the (missing) data points.
+
+        y_lim: List
+            A 2-length list containing the lower and upper limits of the Y-axis range.
         """
 
-        # Additional check to ensure all provided points are good
-        if not isnan(additional_y).any() and not isnan(additional_y).any():
+        # Additional check to ensure all provided data points are good
+        if not isnan(x).any() and not isnan(y).any():
 
-            # Find non-binned data points that are outside the Y domain
+            # Find all data points that are outside the Y-axis range
             outside_y_domain_above = y > y_lim[1]
             outside_y_domain_below = y < y_lim[0]
 
             # X coordinates of the data points whose Y coordinates are outside the
-            # domain
-            x_down_arr = x[outside_y_domain_below]
-            x_up_arr = x[outside_y_domain_above]
+            # Y-axis range
+            x_down_list = x[outside_y_domain_below]
+            x_up_list = x[outside_y_domain_above]
 
             # Use figure's data coordinates along the X axis and relative coordinates
             # along the Y axis.
@@ -327,26 +347,26 @@ class VelociraptorLine(object):
             arrow_length = 0.14
             distance_from_edge = 0.01
 
-            # Loop over arrows pointing down
-            for x_down in x_down_arr:
+            # Draw arrows pointing downwards
+            for x_down in x_down_list:
                 ax.annotate(
                     "",
                     xytext=(x_down, arrow_length + distance_from_edge),
                     textcoords=tform,
                     xy=(x_down, distance_from_edge),
                     xycoords=tform,
-                    arrowprops=dict(color=arrow_color),
+                    arrowprops=dict(color=color),
                 )
 
-            # Loop over arrows pointing up
-            for x_up in x_up_arr:
+            # Draw arrows pointing upwards
+            for x_up in x_up_list:
                 ax.annotate(
                     "",
                     xytext=(x_up, 1.0 - arrow_length + distance_from_edge),
                     textcoords=tform,
                     xy=(x_up, 1.0 - distance_from_edge),
                     xycoords=tform,
-                    arrowprops=dict(color=arrow_color),
+                    arrowprops=dict(color=color),
                 )
 
         return
@@ -431,7 +451,11 @@ class VelociraptorLine(object):
         try:
             ax.scatter(additional_x.value, additional_y.value, color=line.get_color())
 
+            # Enter only if the plot has a valid Y-axis range and there are any
+            # additional data points.
             if y_lim is not None and len(additional_x) > 0:
+
+                # Add arrows to the plot for each data point beyond the Y-axis range
                 self.highlight_data_outside_domain(
                     ax,
                     additional_x.value,
@@ -440,7 +464,7 @@ class VelociraptorLine(object):
                     (y_lim[0].value, y_lim[1].value),
                 )
 
-            # In case the line object is undefined
+        # In case the line object is undefined
         except NameError:
             ax.scatter(additional_x.value, additional_y.value)
 

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -663,9 +663,11 @@ class VelociraptorPlot(object):
         """
 
         if self.median_line is not None:
-            self.median_line.plot_line(ax=ax, x=x, y=y, label="Median")
+            self.median_line.plot_line(
+                ax=ax, x=x, y=y, label="Median", y_lim=self.y_lim
+            )
         if self.mean_line is not None:
-            self.mean_line.plot_line(ax=ax, x=x, y=y, label="Mean")
+            self.mean_line.plot_line(ax=ax, x=x, y=y, label="Mean", y_lim=self.y_lim)
 
         return
 

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -664,10 +664,12 @@ class VelociraptorPlot(object):
 
         if self.median_line is not None:
             self.median_line.plot_line(
-                ax=ax, x=x, y=y, label="Median", y_lim=self.y_lim
+                ax=ax, x=x, y=y, label="Median", x_lim=self.x_lim, y_lim=self.y_lim
             )
         if self.mean_line is not None:
-            self.mean_line.plot_line(ax=ax, x=x, y=y, label="Mean", y_lim=self.y_lim)
+            self.mean_line.plot_line(
+                ax=ax, x=x, y=y, label="Mean", x_lim=self.x_lim, y_lim=self.y_lim
+            )
 
         return
 


### PR DESCRIPTION
Hi @JBorrow 

This is my first attempt to implement the arrow feature.

Below I describe

- what exactly the feature does
- what problems I encountered while implementing it, and how the problems were resolved
- Examples

<h2>Descripton</h2>

- There is a new function `highlight_data_outside_domain()` in ` autoplotter/lines.py` which compares X and Y coordinates of the additional data points to the lower and upper limits of the X and Y axes, respectively. 
- If a data point happens to lie outside the plot's domain, then an arrow is drawn. The arrow indicates where the missing point is. For a given missing data point with its Y(X) coordinate outside the Y(X)-axis range, the corresponding arrow will have the same X(Y) coordinate. If a data point lies outside both the X-axis range and Y-axis range, then a diagonal arrow is drawn (otherwise it is vertical or horizontal). This in total gives 8 different directions of the arrows: up, down, left, and right as well as four diagonal ones.
- Arrows are drawn both in the single-run mode and in the comparison mode.

<h2>Notes on Implementation</h2>

- I am using `ax.annonate()` instead of `ax.arrow()` because, in the latter, the arrow's head looks (very) weird when X- and Y- axis ranges are (very) different.
- I am using the function `blended_transform_factory()` from `matplotlib.transforms` because I want the arrows to have a fixed length regardless of whether the plot is in log or linear.
- At the low level of matplotlib, when `ax.annonate()` is called `\sqrt(x*x + y*y)` is computed. Hence, I need to provide dimensionless coordinates to `ax.annonate()`; otherwise matplotlib will scream while computing that square root.
- I had to make `highlight_data_outside_domain()` be a method of the `line` class, not the `plot` class, because it requires such information as colour, for instance; and it is most convenient to call `highlight_data_outside_domain()` inside the `plot_line()` function.

<h2>Web-page with the plots following this update</h2>

[Single-mode example](http://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/HAWK/L006N188/z1.5_01_REFERENCE/)
[Comparison-mode example](http://swift.dur.ac.uk/COLIBREPlots/chaikin/comparisons/HAWK/L006N188/z1.5_VARY_SNII_E_%5b01,03%5d/)

<h2>Illustration of the feature</h2>

![stellar_mass_halo_mass_M200_centrals_30](https://user-images.githubusercontent.com/20153933/107881148-4dfd2780-6ee3-11eb-9e8c-88d0f345df67.png)
![stellar_mass_halo_mass_M200_all_100](https://user-images.githubusercontent.com/20153933/107881146-4ccbfa80-6ee3-11eb-8a11-39488ef78754.png)



Fixes #45 

