### PR TITLE
Fix bug in the units of stellar ages

### DIFF
--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -733,7 +733,7 @@ def registration_stellar_age(
     """
 
     if field_path == "tage_star":
-        return unit_system.age, "Mean Stellar Age", field_path.lower()
+        return "yr", "Mean Stellar Age", field_path.lower()
     else:
         raise RegistrationDoesNotMatchError
 


### PR DESCRIPTION
@JBorrow  Recall that the plot with the stellar ages is always empty. 

[SEE THIS LINK FOR EXAMPLE](http://swift.dur.ac.uk/COLIBREPlots/chaikin/individual_runs/HAWK/L006N188/z0.0_01_REFERENCE/)

That is because in the registration we are using `977792221513.1456 yr` for the units, whereas in fact the ages are given in `yr`

![Screenshot from 2021-03-03 11-09-32](https://user-images.githubusercontent.com/20153933/109790609-e1d43080-7c11-11eb-82f8-28b7f5a6f5e3.png)

**This PR fixes the bug, which allows the pipeline to produce the correct stellar-ages plots**

![stellar_mass_ages_100](https://user-images.githubusercontent.com/20153933/109790793-0d571b00-7c12-11eb-85a4-2fb3bf00684c.png)



