### PR TITLE
Feature: add minimum number of additional data points

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ unyt
 tqdm
 pyyaml
 black
+matplotlib

--- a/velociraptor/autoplotter/__init__.py
+++ b/velociraptor/autoplotter/__init__.py
@@ -13,7 +13,7 @@ This yaml file has the following format:
      select_structure_type: number of substructure to select (e.g. 10 is centrals)
      selection_mask: "quantity.name" - a boolean quantity to select the items you wish to plot.
      number_of_bins: number of bins in the (background) histogram or massfunc
-     min_num_points_highlight: Minimum number of data points (with the largest values of x) to highlight in the mean-line and median-line plots
+     min_num_points_highlight: Minimum number of data points (with the largest values of x) to highlight in mean- and median-line plots (default: 10)
      reverse_cumsum: reverse the cumulative sum in cumulative histogram plots? Choose true or false
      comment: "An extra string to be placed on the plot"
      legend_loc: Location of legend (string). One of:

--- a/velociraptor/autoplotter/__init__.py
+++ b/velociraptor/autoplotter/__init__.py
@@ -13,6 +13,7 @@ This yaml file has the following format:
      select_structure_type: number of substructure to select (e.g. 10 is centrals)
      selection_mask: "quantity.name" - a boolean quantity to select the items you wish to plot.
      number_of_bins: number of bins in the (background) histogram or massfunc
+     min_num_points_highlight: Minimum number of data points (with the largest values of x) to highlight in the mean-line and median-line plots
      reverse_cumsum: reverse the cumulative sum in cumulative histogram plots? Choose true or false
      comment: "An extra string to be placed on the plot"
      legend_loc: Location of legend (string). One of:

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -490,7 +490,7 @@ class VelociraptorLine(object):
         label: Union[str, None] = None,
         x_lim: Union[List, None] = None,
         y_lim: Union[List, None] = None,
-        min_num_points_highlight=0,
+        min_num_points_highlight: int = 0,
     ):
         """
         Plot a line using these parameters on some axes, x against y.

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -179,6 +179,7 @@ class VelociraptorLine(object):
         y: unyt_array,
         box_volume: Union[None, unyt_quantity] = None,
         reverse_cumsum: bool = False,
+        minimum_additional_points: int = 0,
     ):
         """
         Creates the line!
@@ -201,6 +202,10 @@ class VelociraptorLine(object):
             A boolean deciding whether to reverse the cumulative sum. If false,
             the sum is computed from low to high values (along the X-axis). Relevant
             only for cumulative histogram lines. Default is false.
+
+        minimum_additional_points: int, optional
+            Minimum number of additional data points with the highest values of x to
+            show in the median-line or mean-line plots.
 
         Returns
         -------
@@ -236,11 +241,19 @@ class VelociraptorLine(object):
 
         if self.median:
             self.output = lines.binned_median_line(
-                x=masked_x, y=masked_y, x_bins=self.bins, return_additional=True
+                x=masked_x,
+                y=masked_y,
+                x_bins=self.bins,
+                return_additional=True,
+                minimum_additional_points=minimum_additional_points,
             )
         elif self.mean:
             self.output = lines.binned_mean_line(
-                x=masked_x, y=masked_y, x_bins=self.bins, return_additional=True
+                x=masked_x,
+                y=masked_y,
+                x_bins=self.bins,
+                return_additional=True,
+                minimum_additional_points=minimum_additional_points,
             )
         elif self.mass_function:
             mass_function_output = create_mass_function_given_bins(
@@ -477,6 +490,7 @@ class VelociraptorLine(object):
         label: Union[str, None] = None,
         x_lim: Union[List, None] = None,
         y_lim: Union[List, None] = None,
+        min_num_points_highlight=0,
     ):
         """
         Plot a line using these parameters on some axes, x against y.
@@ -503,6 +517,10 @@ class VelociraptorLine(object):
         y_lim: Union[List, None]
             A 2-length list containing the lower and upper limits of the Y-axis range.
 
+        min_num_points_highlight: int, optional
+            Minimum number of data points with the highest values of x to highlight in
+            the median-line or mean-line plots.
+
         Notes
         -----
 
@@ -514,7 +532,7 @@ class VelociraptorLine(object):
             return
 
         centers, heights, errors, additional_x, additional_y = self.create_line(
-            x=x, y=y
+            x=x, y=y, minimum_additional_points=min_num_points_highlight
         )
 
         if self.scatter == "none" or errors is None:

--- a/velociraptor/autoplotter/metadata.py
+++ b/velociraptor/autoplotter/metadata.py
@@ -15,7 +15,6 @@ from velociraptor.autoplotter.lines import VelociraptorLine
 from typing import List, Dict
 
 import yaml
-from unyt import unyt_array
 
 
 class VelociraptorLineMetadata(object):

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -72,11 +72,14 @@ class VelociraptorPlot(object):
     cumulative_histogram_line: Union[None, VelociraptorLine]
     # Binning for x, y axes.
     number_of_bins: int
+    # Minimum number of data points (with the largest values of x) to highlight in the
+    # mean-line and median-line plots
+    min_num_points_highlight: int
     # Whether to reverse cumulative sum. If true, do the summation from high to low
     reverse_cumsum: bool
     x_bins: unyt_array
     y_bins: unyt_array
-    # Select a specific strucutre type?
+    # Select a specific structure type?
     select_structure_type: Union[None, int]
     structure_mask: Union[None, array]
     selection_mask: Union[None, array]
@@ -662,13 +665,30 @@ class VelociraptorPlot(object):
         Adds any lines present to the given axes.
         """
 
+        # Fetch the minimum number of points to highlight
+        self.min_num_points_highlight = self.data.get(
+            "min_num_points_highlight", 10
+        )
+
         if self.median_line is not None:
             self.median_line.plot_line(
-                ax=ax, x=x, y=y, label="Median", x_lim=self.x_lim, y_lim=self.y_lim
+                ax=ax,
+                x=x,
+                y=y,
+                label="Median",
+                x_lim=self.x_lim,
+                y_lim=self.y_lim,
+                min_num_points_highlight=self.min_num_points_highlight,
             )
         if self.mean_line is not None:
             self.mean_line.plot_line(
-                ax=ax, x=x, y=y, label="Mean", x_lim=self.x_lim, y_lim=self.y_lim
+                ax=ax,
+                x=x,
+                y=y,
+                label="Mean",
+                x_lim=self.x_lim,
+                y_lim=self.y_lim,
+                min_num_points_highlight=self.min_num_points_highlight,
             )
 
         return

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -242,6 +242,9 @@ class VelociraptorPlot(object):
         except KeyError:
             setattr(self, f"{line_type}_line", None)
 
+        # Fetch the minimum number of points to highlight
+        self.min_num_points_highlight = self.data.get("min_num_points_highlight", 10)
+
         return
 
     def _parse_lines(self) -> None:
@@ -664,11 +667,6 @@ class VelociraptorPlot(object):
         """
         Adds any lines present to the given axes.
         """
-
-        # Fetch the minimum number of points to highlight
-        self.min_num_points_highlight = self.data.get(
-            "min_num_points_highlight", 10
-        )
 
         if self.median_line is not None:
             self.median_line.plot_line(

--- a/velociraptor/autoplotter/plot.py
+++ b/velociraptor/autoplotter/plot.py
@@ -8,7 +8,7 @@ import unyt
 
 from matplotlib import rcParams
 
-from matplotlib.colors import Normalize, LogNorm
+from matplotlib.colors import LogNorm
 from velociraptor import VelociraptorCatalogue
 from velociraptor.autoplotter.objects import VelociraptorLine
 from typing import Tuple, Union
@@ -17,7 +17,7 @@ import velociraptor.tools as tools
 
 
 def scatter_x_against_y(
-    x: unyt.unyt_array, y: unyt.unyt_quantity
+    x: unyt.unyt_array, y: unyt.unyt_array
 ) -> Tuple[plt.Figure, plt.Axes]:
     """
     Creates a scatter of x against y (unyt arrays).

--- a/velociraptor/tools/lines.py
+++ b/velociraptor/tools/lines.py
@@ -105,15 +105,15 @@ def binned_mean_line(
         x, y = x[idx_sort], y[idx_sort]
 
         # Ensure we don't run out of data points to plot
-        N_points_to_plot = min(minimum_additional_points, len(x))
+        num_points_to_plot = min(minimum_additional_points, len(x))
 
-        # Collect 'N_points_to_plot' additional data points
-        additional_x += list(x[-N_points_to_plot:].value)
-        additional_y += list(y[-N_points_to_plot:].value)
+        # Collect 'num_points_to_plot' additional data points
+        additional_x += list(x[-num_points_to_plot:].value)
+        additional_y += list(y[-num_points_to_plot:].value)
 
         # Don't use the collected additional data points for the bins
-        x = x[:-N_points_to_plot]
-        y = y[:-N_points_to_plot]
+        x = x[:-num_points_to_plot]
+        y = y[:-num_points_to_plot]
 
     hist = np.digitize(x, x_bins)
 
@@ -259,15 +259,15 @@ def binned_median_line(
         x, y = x[idx_sort], y[idx_sort]
 
         # Ensure we don't run out of data points to plot
-        N_points_to_plot = min(minimum_additional_points, len(x))
+        num_points_to_plot = min(minimum_additional_points, len(x))
 
-        # Collect 'N_points_to_plot' additional data points
-        additional_x += list(x[-N_points_to_plot:].value)
-        additional_y += list(y[-N_points_to_plot:].value)
+        # Collect 'num_points_to_plot' additional data points
+        additional_x += list(x[-num_points_to_plot:].value)
+        additional_y += list(y[-num_points_to_plot:].value)
 
         # Don't use the collected additional data points for the bins
-        x = x[:-N_points_to_plot]
-        y = y[:-N_points_to_plot]
+        x = x[:-num_points_to_plot]
+        y = y[:-num_points_to_plot]
 
     hist = np.digitize(x, x_bins)
 


### PR DESCRIPTION
**Add the minimum number of additional data points to show in mean-line and median-line plots**

- We need this feature because we always want to know what the largest objects are doing. If some objects become part of median-line bins it becomes increasingly harder to tell what is going on
- I set the default value to be 10, but since we may want different numbers for different plots, I make it possible to set it for every plot through a new parameter in autoplotter's .yml config
- I don't like that the new argument first goes to `plot_line()`, then to `create_line()`, and then to `binned_median_line()`. Maybe we can shorten the path?

**Example:**

![stellar_mass_galaxy_size_30](https://user-images.githubusercontent.com/20153933/111052426-f65ac900-845a-11eb-8c3e-ef1c07cfd1b8.png)

Also, **housekeeping**

- Add the missing `matplotlib` dependence in requirements.txt
- To tiny changes in `velociraptor/autoplotter/plot.py`
