### PR TITLE
Fix typo in the registration of the fields with H2 and HI masses

### DIFF
--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -873,7 +873,7 @@ def registration_gas_species_masses(
 
     # Capture aperture size
     match_string = (
-        "Aperture_([a-zA-Z]*)_index_0_aperture_total_gas_([0-9]*)_kpc"
+        "Aperture_([a-zA-Z]*)_aperture_total_gas_([0-9]*)_kpc"
     )
     regex = cached_regex(match_string)
 


### PR DESCRIPTION
The new fields for H2 and HI masses in the VR catalogue have names like `Aperture_AtomicHydrogenMasses_aperture_total_gas_100_kpc`

Since `_index_0` is not present in the names, the velociraptor python library won't register them 