### PR TITLE
Fix annoying bug with empty axes labels and wrong axes limits

### DIFF
--- a/velociraptor/tools/lines.py
+++ b/velociraptor/tools/lines.py
@@ -142,6 +142,11 @@ def binned_mean_line(
     additional_x += list(x[above_highest].value)
     additional_y += list(y[above_highest].value)
 
+    # If there is nothing to plot as the mean line, add a test point to avoid having
+    # empty axes labels or/and wrong axes limits
+    if len(means) == 0:
+        means, centers, standard_deviations = [0], [0], [0]
+
     means = unyt.unyt_array(means, units=y.units, name=y.name)
     standard_deviations = unyt.unyt_array(
         standard_deviations, units=y.units, name=f"{y.name} ($sigma$)"
@@ -295,6 +300,11 @@ def binned_median_line(
     above_highest = hist == len(x_bins)
     additional_x += list(x[above_highest].value)
     additional_y += list(y[above_highest].value)
+
+    # If there is nothing to plot as the median line, add a test point to avoid having
+    # empty axes labels or/and wrong axes limits
+    if len(medians) == 0:
+        medians, centers, deviations = [0], [0], [[0, 0]]
 
     medians = unyt.unyt_array(medians, units=y.units, name=y.name)
     # Percentiles actually gives us the values - we want to be able to use

--- a/velociraptor/tools/lines.py
+++ b/velociraptor/tools/lines.py
@@ -4,7 +4,7 @@ Tools to generate various lines from datasets.
 
 import unyt
 import numpy as np
-
+import sys
 from typing import List
 
 
@@ -145,7 +145,8 @@ def binned_mean_line(
     # If there is nothing to plot as the mean line, add a test point to avoid having
     # empty axes labels or/and wrong axes limits
     if len(means) == 0:
-        means, centers, standard_deviations = [0], [0], [0]
+        float_min = sys.float_info.min
+        means, centers, standard_deviations = [float_min], [float_min], [float_min]
 
     means = unyt.unyt_array(means, units=y.units, name=y.name)
     standard_deviations = unyt.unyt_array(
@@ -304,7 +305,12 @@ def binned_median_line(
     # If there is nothing to plot as the median line, add a test point to avoid having
     # empty axes labels or/and wrong axes limits
     if len(medians) == 0:
-        medians, centers, deviations = [0], [0], [[0, 0]]
+        float_min = sys.float_info.min
+        medians, centers, deviations = (
+            [float_min],
+            [float_min],
+            [[float_min, float_min]],
+        )
 
     medians = unyt.unyt_array(medians, units=y.units, name=y.name)
     # Percentiles actually gives us the values - we want to be able to use


### PR DESCRIPTION
**Fixes very annoying bug** 

The fix is not perfect, but it works. The bug has to do with empty axes labels and wrong axes limits in the case that the median/mean line arrays are **empty**

<h2>EXAMPLE 1</h2>
<h3>BEFORE THE FIX</h3>

![H2_mass_star_formation_rate_100_bad](https://user-images.githubusercontent.com/20153933/114054888-8809fa80-9890-11eb-9cd4-5d91c5190a46.png)

<h3>AFTER THE FIX</h3>

![H2_mass_star_formation_rate_100_good](https://user-images.githubusercontent.com/20153933/114054985-9fe17e80-9890-11eb-9ed2-8231673fc95c.png)


<h2>EXAMPLE 2</h2>
<h3>BEFORE THE FIX</h3>

![h2_frac_func_ssfr_bad](https://user-images.githubusercontent.com/20153933/114054880-87716400-9890-11eb-8500-7f8b16626c67.png)

<h3>AFTER THE FIX</h3>

![h2_frac_func_ssfr_good](https://user-images.githubusercontent.com/20153933/114055011-a7088c80-9890-11eb-9b70-a9475d4b62fc.png)

