### PR TITLE
Exclude structure type

### DIFF
--- a/velociraptor/autoplotter/__init__.py
+++ b/velociraptor/autoplotter/__init__.py
@@ -10,7 +10,8 @@ This yaml file has the following format:
    output_filename:
      # Global plot quantities
      type: scatter / histogram / cumulative_histogram / 2dhistogram / massfunction / adaptivemassfunction
-     select_structure_type: number of substructure to select (e.g. 10 is centrals)
+     select_structure_type: number of substructure to select (e.g. 10 for centrals)
+     exclude_structure_type: number of substructure to exclude (e.g. 10 for non-centrals). Cannot be a number equal to select_structure_type.
      selection_mask: "quantity.name" - a boolean quantity to select the items you wish to plot.
      number_of_bins: number of bins in the (background) histogram or massfunc
      min_num_points_highlight: Minimum number of data points (with the largest values of x) to highlight in mean- and median-line plots (default: 10)

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -462,7 +462,8 @@ class VelociraptorPlot(object):
         self._parse_loc()
         self._parse_comment()
         self._parse_lines()
-        self._parse_structure_type()
+        self._parse_select_structure_type()
+        self._parse_exclude_structure_type()
         self._parse_selection_mask()
 
         return
@@ -503,7 +504,8 @@ class VelociraptorPlot(object):
         self._parse_coordinate_histogram_bin("x")
         self._parse_loc()
         self._parse_comment()
-        self._parse_structure_type()
+        self._parse_select_structure_type()
+        self._parse_exclude_structure_type()
         self._parse_selection_mask()
 
         return

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -84,6 +84,7 @@ class VelociraptorPlot(object):
     y_bins: unyt_array
     # Select a specific structure type?
     select_structure_type: Union[None, int]
+    exclude_structure_type: Union[None, int]
     structure_mask: Union[None, array]
     selection_mask: Union[None, array]
     # Where should the legend and z, a information be placed?
@@ -260,7 +261,7 @@ class VelociraptorPlot(object):
 
         return
 
-    def _parse_structure_type(self) -> None:
+    def _parse_select_structure_type(self) -> None:
         """
         Parses the structure type selector to select_structure_type, as well as
         creating the structure_mask
@@ -269,6 +270,22 @@ class VelociraptorPlot(object):
             self.select_structure_type = int(self.data["select_structure_type"])
         except KeyError:
             self.select_structure_type = None
+
+        # Initialise to None; we set/create this when we first have access to the
+        # catalogue in the plotting functions.
+        self.structure_mask = None
+
+        return
+
+    def _parse_exclude_structure_type(self) -> None:
+        """
+        Parses the structure type excluder to exclude_structure_type, as well as
+        creating the structure_mask
+        """
+        try:
+            self.exclude_structure_type = int(self.data["exclude_structure_type"])
+        except KeyError:
+            self.exclude_structure_type = None
 
         # Initialise to None; we set/create this when we first have access to the
         # catalogue in the plotting functions.
@@ -745,18 +762,44 @@ class VelociraptorPlot(object):
             ).astype(bool)
 
             if self.select_structure_type is not None:
+                if self.select_structure_type == self.exclude_structure_type:
+                    raise AutoPlotterError(
+                        f"Cannot simultaneously select and exclude structure"
+                        " type {self.select_structure_type}"
+                    )
                 self.structure_mask = logical_and(
                     self.structure_mask,
                     catalogue.structure_type.structuretype
                     == self.select_structure_type,
                 )
 
+            elif self.exclude_structure_type is not None:
+                self.structure_mask = logical_and(
+                    self.structure_mask,
+                    catalogue.structure_type.structuretype
+                    != self.exclude_structure_type,
+                )
+                
             x = x[self.structure_mask]
             x.name = name
         elif self.select_structure_type is not None:
+            if self.select_structure_type == self.exclude_structure_type:
+                raise AutoPlotterError(
+                    f"Cannot simultaneously select and exclude structure"
+                    " type {self.select_structure_type}"
+                )
+            
             # Need to create mask
             self.structure_mask = (
                 catalogue.structure_type.structuretype == self.select_structure_type
+            )
+
+            x = x[self.structure_mask]
+            x.name = name
+        elif self.exclude_structure_type is not None:
+            # Need to create mask
+            self.structure_mask = (
+                catalogue.structure_type.structuretype != self.exclude_structure_type
             )
 
             x = x[self.structure_mask]

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1496,7 +1496,6 @@ global_registration_functions = {
         "dust_masses",
         "gas_element_ratios_times_masses",
         "stellar_luminosities",
-        "element_ratios_times_masses",
         "cold_dense_gas_properties",
         "log_element_ratios_times_masses",
         "lin_element_ratios_times_masses",

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1022,43 +1022,54 @@ def registration_gas_hydrogen_species_masses(
         raise RegistrationDoesNotMatchError
 
 
-def registration_gas_element_ratios_times_masses(
+def registration_element_ratios_times_masses(
     field_path: str, unit_system: VelociraptorUnits
 ) -> (unyt.Unit, str, str):
     """
-    Registers the Fe/H times mass and O/H times mass within apertures
+    Registers the log10(Fe/H) times mass and log10(O/H) times mass within apertures for two particle floor values
     """
 
     unit = unit_system.mass
 
     # Capture aperture size
-    match_string = "Aperture_([a-zA-Z]*)_aperture_total_gas_([0-9]*)_kpc"
+    match_string = (
+        "Aperture_([a-zA-Z]*)Masses(Lo|Hi)Floor_aperture_total_([a-zA-Z]*)_([0-9]*)_kpc"
+    )
     regex = cached_regex(match_string)
 
     match = regex.match(field_path)
 
     if match:
         long_species = match.group(1)
-        aperture_size = match.group(2)
+        floor_type = match.group(2)
+        part_type = match.group(3)
+        aperture_size = match.group(4)
 
         try:
             short_species = {
-                "OxygenOverHydrogenMasses": "O_over_H",
-                "IronOverHydrogenMasses": "Fe_over_H",
+                "LogOxygenOverHydrogen": "O_over_H",
+                "LogIronOverHydrogen": "Fe_over_H",
             }[long_species]
             element_name = {
-                "OxygenOverHydrogenMasses": "Oxygen",
-                "IronOverHydrogenMasses": "Iron",
+                "LogOxygenOverHydrogen": "Oxygen",
+                "LogIronOverHydrogen": "Iron",
             }[long_species]
             fraction_name = {
-                "OxygenOverHydrogenMasses": "(O/H)",
-                "IronOverHydrogenMasses": "(Fe/H)",
+                "LogOxygenOverHydrogen": "O/H",
+                "LogIronOverHydrogen": "Fe/H",
             }[long_species]
+
+            short_floortype = {"Lo": "lowfloor", "Hi": "highfloor",}[floor_type]
+            floor_value = {"Lo": "-4", "Hi": "-3",}[floor_type]
         except KeyError:
             raise RegistrationDoesNotMatchError
 
-        full_name = f"{element_name} Abundance Weighted Gas Mass {fraction_name}$\times M_{{\\rm gas}}$ ({aperture_size} kpc)"
-        snake_case = f"{short_species}_times_gas_mass_{aperture_size}_kpc"
+        full_name = f"""Log10 {element_name} Abundance Weighted {part_type.capitalize()} Mass ({fraction_name}) 
+        $\times M_{{\\rm gas}}$, from particle values floored at [{fraction_name}]$\\gtreq {floor_value}$ 
+        ({aperture_size} kpc)"""
+        snake_case = (
+            f"log_{short_species}_times_{part_type}_mass_{short_floortype}_{aperture_size}_kpc"
+        )
 
         return unit, full_name, snake_case
     else:
@@ -1403,6 +1414,7 @@ global_registration_functions = {
         "dust_masses",
         "gas_element_ratios_times_masses",
         "stellar_luminosities",
+        "element_ratios_times_masses",
         "fail_all",
     ]
 }

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1021,6 +1021,7 @@ def registration_gas_hydrogen_species_masses(
     else:
         raise RegistrationDoesNotMatchError
 
+
 def registration_cold_dense_gas_properties(
     field_path: str, unit_system: VelociraptorUnits
 ) -> (unyt.Unit, str, str):
@@ -1030,9 +1031,7 @@ def registration_cold_dense_gas_properties(
     unit = unit_system.mass
 
     # Capture aperture size
-    match_string = (
-        "Aperture_ColdDense([a-zA-Z]*)Masses_aperture_total_gas_([0-9]*)_kpc"
-    )
+    match_string = "Aperture_ColdDense([a-zA-Z]*)Masses_aperture_total_gas_([0-9]*)_kpc"
     regex = cached_regex(match_string)
     match = regex.match(field_path)
 
@@ -1041,17 +1040,15 @@ def registration_cold_dense_gas_properties(
         aperture_size = match.group(2)
 
         try:
-            long_quantity = {
-                "DiffuseMetal": "Diffuse Metal",
-                "Gas": "Gas",
-            }[quantity_key]
-            short_quantity = {
-                "DiffuseMetal": "diffuse_metal",
-                "Gas": "gas",
-            }[quantity_key]
+            long_quantity = {"DiffuseMetal": "Diffuse Metal", "Gas": "Gas",}[
+                quantity_key
+            ]
+            short_quantity = {"DiffuseMetal": "diffuse_metal", "Gas": "gas",}[
+                quantity_key
+            ]
         except KeyError:
             raise RegistrationDoesNotMatchError
-        
+
         full_name = f"""{long_quantity} Masses in Cold, Dense ($T < 10^{{4.5}}\;{{\rm K}}$,  
         $n_{{\\rm H}}$ > 0.1 \\; {{\rm cm^{{-3}}}}$) Gas ({aperture_size} kpc)"""
         snake_case = f"cold_dense_{short_quantity}_mass_{aperture_size}_kpc"
@@ -1059,7 +1056,7 @@ def registration_cold_dense_gas_properties(
     else:
         raise RegistrationDoesNotMatchError
 
-    
+
 def registration_log_element_ratios_times_masses(
     field_path: str, unit_system: VelociraptorUnits
 ) -> (unyt.Unit, str, str):
@@ -1110,6 +1107,7 @@ def registration_log_element_ratios_times_masses(
     else:
         raise RegistrationDoesNotMatchError
 
+
 def registration_lin_element_ratios_times_masses(
     field_path: str, unit_system: VelociraptorUnits
 ) -> (unyt.Unit, str, str):
@@ -1120,9 +1118,7 @@ def registration_lin_element_ratios_times_masses(
     unit = unit_system.mass
 
     # Capture aperture size
-    match_string = (
-        "Aperture_([a-zA-Z]*)Masses_aperture_total_([a-zA-Z]*)_([0-9]*)_kpc"
-    )
+    match_string = "Aperture_([a-zA-Z]*)Masses_aperture_total_([a-zA-Z]*)_([0-9]*)_kpc"
     regex = cached_regex(match_string)
 
     match = regex.match(field_path)
@@ -1144,7 +1140,7 @@ def registration_lin_element_ratios_times_masses(
                 "IronOverHydrogen": "Iron",
             }[long_species]
             fraction_name = {
-                "TotalOxygenOverHydrogen": "O/H", 
+                "TotalOxygenOverHydrogen": "O/H",
                 "OxygenOverHydrogen": "O/H",
                 "IronOverHydrogen": "Fe/H",
             }[long_species]
@@ -1157,6 +1153,7 @@ def registration_lin_element_ratios_times_masses(
         return unit, full_name, snake_case
     else:
         raise RegistrationDoesNotMatchError
+
 
 def registration_dust_masses(
     field_path: str, unit_system: VelociraptorUnits

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1021,8 +1021,46 @@ def registration_gas_hydrogen_species_masses(
     else:
         raise RegistrationDoesNotMatchError
 
+def registration_cold_dense_gas_properties(
+    field_path: str, unit_system: VelociraptorUnits
+) -> (unyt.Unit, str, str):
+    """
+    Registers the mass of cold (T < 10^4.5 K), dense (nH > 0.1 cm^-3) gas in apertures.
+    """
+    unit = unit_system.mass
 
-def registration_element_ratios_times_masses(
+    # Capture aperture size
+    match_string = (
+        "Aperture_ColdDense([a-zA-Z]*)Masses_aperture_total_gas_([0-9]*)_kpc"
+    )
+    regex = cached_regex(match_string)
+    match = regex.match(field_path)
+
+    if match:
+        quantity_key = match.group(1)
+        aperture_size = match.group(2)
+
+        try:
+            long_quantity = {
+                "DiffuseMetal": "Diffuse Metal",
+                "Gas": "Gas",
+            }[quantity_key]
+            short_quantity = {
+                "DiffuseMetal": "diffuse_metal",
+                "Gas": "gas",
+            }[quantity_key]
+        except KeyError:
+            raise RegistrationDoesNotMatchError
+        
+        full_name = f"""{long_quantity} Masses in Cold, Dense ($T < 10^{{4.5}}\;{{\rm K}}$,  
+        $n_{{\\rm H}}$ > 0.1 \\; {{\rm cm^{{-3}}}}$) Gas ({aperture_size} kpc)"""
+        snake_case = f"cold_dense_{short_quantity}_mass_{aperture_size}_kpc"
+        return unit, full_name, snake_case
+    else:
+        raise RegistrationDoesNotMatchError
+
+    
+def registration_log_element_ratios_times_masses(
     field_path: str, unit_system: VelociraptorUnits
 ) -> (unyt.Unit, str, str):
     """
@@ -1068,11 +1106,57 @@ def registration_element_ratios_times_masses(
         $\times M_{{\\rm gas}}$, from particle values floored at [{fraction_name}]$\\gtreq {floor_value}$ 
         ({aperture_size} kpc)"""
         snake_case = f"log_{short_species}_times_{part_type}_mass_{short_floortype}_{aperture_size}_kpc"
-
         return unit, full_name, snake_case
     else:
         raise RegistrationDoesNotMatchError
 
+def registration_lin_element_ratios_times_masses(
+    field_path: str, unit_system: VelociraptorUnits
+) -> (unyt.Unit, str, str):
+    """
+    Registers the Fe/H times mass and O/H times mass within apertures for two particle floor values
+    """
+
+    unit = unit_system.mass
+
+    # Capture aperture size
+    match_string = (
+        "Aperture_([a-zA-Z]*)Masses_aperture_total_([a-zA-Z]*)_([0-9]*)_kpc"
+    )
+    regex = cached_regex(match_string)
+
+    match = regex.match(field_path)
+
+    if match:
+        long_species = match.group(1)
+        part_type = match.group(2)
+        aperture_size = match.group(3)
+
+        try:
+            short_species = {
+                "TotalOxygenOverHydrogen": "O_over_H_total",
+                "OxygenOverHydrogen": "O_over_H",
+                "IronOverHydrogen": "Fe_over_H",
+            }[long_species]
+            element_name = {
+                "TotalOxygenOverHydrogen": "Oxygen",
+                "OxygenOverHydrogen": "Oxygen",
+                "IronOverHydrogen": "Iron",
+            }[long_species]
+            fraction_name = {
+                "TotalOxygenOverHydrogen": "O/H", 
+                "OxygenOverHydrogen": "O/H",
+                "IronOverHydrogen": "Fe/H",
+            }[long_species]
+        except KeyError:
+            raise RegistrationDoesNotMatchError
+
+        full_name = f"""Linear {element_name} Abundance Weighted {part_type.capitalize()} Mass ({fraction_name}) 
+        $\times M_{{\\rm gas}}$ ({aperture_size} kpc)"""
+        snake_case = f"lin_{short_species}_times_{part_type}_mass_{aperture_size}_kpc"
+        return unit, full_name, snake_case
+    else:
+        raise RegistrationDoesNotMatchError
 
 def registration_dust_masses(
     field_path: str, unit_system: VelociraptorUnits
@@ -1413,6 +1497,9 @@ global_registration_functions = {
         "gas_element_ratios_times_masses",
         "stellar_luminosities",
         "element_ratios_times_masses",
+        "cold_dense_gas_properties",
+        "log_element_ratios_times_masses",
+        "lin_element_ratios_times_masses",
         "fail_all",
     ]
 }

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1067,9 +1067,7 @@ def registration_element_ratios_times_masses(
         full_name = f"""Log10 {element_name} Abundance Weighted {part_type.capitalize()} Mass ({fraction_name}) 
         $\times M_{{\\rm gas}}$, from particle values floored at [{fraction_name}]$\\gtreq {floor_value}$ 
         ({aperture_size} kpc)"""
-        snake_case = (
-            f"log_{short_species}_times_{part_type}_mass_{short_floortype}_{aperture_size}_kpc"
-        )
+        snake_case = f"log_{short_species}_times_{part_type}_mass_{short_floortype}_{aperture_size}_kpc"
 
         return unit, full_name, snake_case
     else:

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1494,7 +1494,6 @@ global_registration_functions = {
         "gas_diffuse_element_masses",
         "dust_masses_from_table",
         "dust_masses",
-        "gas_element_ratios_times_masses",
         "stellar_luminosities",
         "cold_dense_gas_properties",
         "log_element_ratios_times_masses",

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1048,9 +1048,10 @@ def registration_cold_dense_gas_properties(
             ]
         except KeyError:
             raise RegistrationDoesNotMatchError
-
-        full_name = f"""{long_quantity} Masses in Cold, Dense ($T < 10^{{4.5}}\;{{\rm K}}$,  
-        $n_{{\\rm H}}$ > 0.1 \\; {{\rm cm^{{-3}}}}$) Gas ({aperture_size} kpc)"""
+        full_name = (
+            f"{long_quantity} Masses in Cold, Dense ($T < 10^{{4.5}}\;{{\rm K}}$, "
+            f"$n_{{\\rm H}}$ > 0.1 \\; {{\rm cm^{{-3}}}}$) Gas ({aperture_size} kpc)"
+        )
         snake_case = f"cold_dense_{short_quantity}_mass_{aperture_size}_kpc"
         return unit, full_name, snake_case
     else:


### PR DESCRIPTION
implement option to exclude a structure number to complement the include option, allowing isolation of satellites 

Rebased onto https://github.com/SWIFTSIM/velociraptor-python/pull/55 , will change from draft to active status once PR55 merged.