### PR TITLE
Draft: Split catalogue reader

### DIFF
--- a/velociraptor/catalogue/reader.py
+++ b/velociraptor/catalogue/reader.py
@@ -10,12 +10,29 @@ import numpy as np
 
 
 class VelociraptorCatalogueReader(object):
+    """
+    VELOCIraptor catalogue reader. Pass it the name of a catalogue file and it
+    will detect whether this catalogue is self-contained or part of a larger
+    split catalogue consisting of multiple files.
+
+    When a split catalogue is used, any of the catalogue.properties.X files can
+    be passed on to the constructor, where X is a counter ranging from 0 to
+    properties_file["Num_of_files"]-1. When a dataset is extracted from such a
+    catalogue, the elements in the resulting dataset will be ordered in blocks
+    of increasing X.
+
+    For split catalogues, this class's read_field() method handles reading the
+    distributed datasets. For unsplit catalogues, it behaves exactly the same
+    as a direct read from the HDF5 file.
+    """
+
     def __init__(self, filename):
         with h5py.File(filename, "r") as handle:
             num_files = handle["Num_of_files"][0]
         if num_files == 1:
             self.filenames = [filename]
         else:
+            # compose the other file names
             basename = re.match("(\S+properties)\.\d+\Z", filename).groups()[0]
             self.filenames = [f"{basename}.{idx}" for idx in range(num_files)]
 
@@ -29,7 +46,8 @@ class VelociraptorCatalogueReader(object):
                     return None
             return value
         else:
-            # figure out the shape and dtype of the return value
+            # figure out the shape and dtype of the return value, so that we can
+            # create the appropriate array
             dtype = None
             shape = None
             for filename in self.filenames:
@@ -43,11 +61,17 @@ class VelociraptorCatalogueReader(object):
                         dtype = ds.dtype
                         shape = ds.shape
                     else:
-                        shape[0] += ds.shape[0]
+                        # tuples are immutable, so instead of
+                        # shape[0]+= ds.shape[0], we have to unpack, sum and
+                        # then pack again
+                        shape0, *shaperest = shape
+                        shape0 += ds.shape[0]
+                        shape = (shape0, *shaperest)
 
             # create an empty array to store the return value
             value = np.zeros(shape, dtype=dtype)
-            # now read the data (no need to check for existence again)
+            # now read the data (no need to check for existence again, this was
+            # done when getting the shape and type)
             offset = 0
             for filename in self.filenames:
                 with h5py.File(filename, "r") as handle:

--- a/velociraptor/catalogue/reader.py
+++ b/velociraptor/catalogue/reader.py
@@ -1,0 +1,57 @@
+"""
+Main objects for the velociraptor reading library.
+
+This is based upon the reading routines in the SWIFTsimIO library.
+"""
+
+import h5py
+import re
+import numpy as np
+
+
+class VelociraptorCatalogueReader(object):
+    def __init__(self, filename):
+        with h5py.File(filename, "r") as handle:
+            num_files = handle["Num_of_files"][0]
+        if num_files == 1:
+            self.filenames = [filename]
+        else:
+            basename = re.match("(\S+properties)\.\d+\Z", filename).groups()[0]
+            self.filenames = [f"{basename}.{idx}" for idx in range(num_files)]
+
+    def read_field(self, field):
+        if len(self.filenames) == 1:
+            with h5py.File(self.filenames[0], "r") as handle:
+                try:
+                    value = handle[field][...]
+                except KeyError:
+                    print(f"Could not read {field}")
+                    return None
+            return value
+        else:
+            # figure out the shape and dtype of the return value
+            dtype = None
+            shape = None
+            for filename in self.filenames:
+                with h5py.File(filename, "r") as handle:
+                    try:
+                        ds = handle[field]
+                    except KeyError:
+                        print(f"Could not read {field}")
+                        return None
+                    if dtype is None:
+                        dtype = ds.dtype
+                        shape = ds.shape
+                    else:
+                        shape[0] += ds.shape[0]
+
+            # create an empty array to store the return value
+            value = np.zeros(shape, dtype=dtype)
+            # now read the data (no need to check for existence again)
+            offset = 0
+            for filename in self.filenames:
+                with h5py.File(filename, "r") as handle:
+                    size = handle[field].shape[0]
+                    value[offset : offset + size] = handle[field][...]
+                    offset += size
+            return value


### PR DESCRIPTION
This adds support for reading distributed VR catalogues, as requested in #72. Metadata is present in each file of a distributed catalogue, so the only significant difference between a normal and a distributed catalogue is the way you read datasets. This is handled by using a new `VelociraptorCatalogueReader` object that takes care of reading and distinguishes between single file and distributed file reads.

Currently I have only implemented this for the actual catalogue (`*properties.*` files), but I assume something similar would need to be done for the particle and SO files.