### PR TITLE
Add ability to mask catalogue

### DIFF
--- a/docs/source/basic_usage/index.rst
+++ b/docs/source/basic_usage/index.rst
@@ -62,6 +62,11 @@ based on the unit metadata in the file.
 There is also full unit information available in the ``data.units`` object, with
 an ``astropy`` cosmology object provided as ``data.units.cosmology``.
 
+Subsets of the catalogue can be read by providing a mask, for instance to read only values for the 3rd object in the catalogue (indexed from 0):
+
+.. code-block:: python
+   masked_data = load("/path/to/catalogue.properties", mask=3)
+
 Creating your first plot
 ------------------------
 

--- a/docs/source/particles_files/index.rst
+++ b/docs/source/particles_files/index.rst
@@ -31,7 +31,8 @@ This returns two objects, ``particles``, and ``unbound_particles``,
 corresponding to both the bound and unbound component of your halo
 respectively. Each of these contains the information required to extract just
 those particles from a snapshot (this is made much easier by using the SWIFT
-integration, shown below).
+integration, shown below). Note that use of a masked ``catalogue`` is not
+supported.
 
 The instances of
 :class:`velociraptor.particles.particles.VelociraptorParticles` have several

--- a/velociraptor/__init__.py
+++ b/velociraptor/__init__.py
@@ -30,19 +30,14 @@ except RuntimeError:
 from velociraptor.catalogue.catalogue import VelociraptorCatalogue
 from velociraptor.__version__ import __version__
 
-try:
-    from types import EllipsisType  # python3.10+
-except ImportError:
-    from typing import Any as EllipsisType  # better choice for this?
 from typing import Union
-from numpy.typing import NDArray
 
 
 def load(
     filename: str,
     disregard_units: bool = False,
     registration_file_path: Union[str, None] = None,
-    mask: Union[EllipsisType, NDArray[bool], int] = Ellipsis
+    mask: slice = Ellipsis
 ) -> VelociraptorCatalogue:
     """
     Loads a velociraptor catalogue, producing a VelociraptorCatalogue

--- a/velociraptor/__init__.py
+++ b/velociraptor/__init__.py
@@ -31,12 +31,14 @@ from velociraptor.catalogue.catalogue import VelociraptorCatalogue
 from velociraptor.__version__ import __version__
 
 from typing import Union
+from numpy.typing import NDArray
 
 
 def load(
     filename: str,
     disregard_units: bool = False,
     registration_file_path: Union[str, None] = None,
+    mask: Union[None, NDArray[bool], int] = None
 ) -> VelociraptorCatalogue:
     """
     Loads a velociraptor catalogue, producing a VelociraptorCatalogue
@@ -63,6 +65,11 @@ def load(
         additional properties with the catalogue. This is an
         advanced feature. See the documentation for more details.
 
+    mask: Union[None, NDArray[bool], int], optional
+        If a boolean array is provided, it is used to mask all
+        catalogue arrays. If an int is provided, catalogue arrays
+        are masked to the single corresponding element.
+
 
     Returns
     -------
@@ -72,7 +79,11 @@ def load(
         .properties file.
     """
 
-    catalogue = VelociraptorCatalogue(filename, disregard_units=disregard_units)
+    catalogue = VelociraptorCatalogue(
+        filename,
+        disregard_units=disregard_units,
+        mask=mask
+    )
 
     if registration_file_path is not None:
         catalogue.register_derived_quantities(registration_file_path)

--- a/velociraptor/catalogue/catalogue.py
+++ b/velociraptor/catalogue/catalogue.py
@@ -9,6 +9,7 @@ import unyt
 
 import numpy as np
 
+from types import EllipsisType
 from typing import Union, Callable, List, Dict
 from numpy.typing import NDArray
 
@@ -123,9 +124,6 @@ def generate_getter(
             with h5py.File(filename, "r") as handle:
                 try:
                     mask = getattr(self, "mask")
-                    # would rather set the default value of mask to Ellipsis, but
-                    # can't work out the type hint for this
-                    mask = Ellipsis if mask is None else mask
                     setattr(self, f"_{name}", unyt.unyt_array(handle[field][mask], unit))
                     getattr(self, f"_{name}").name = full_name
                     getattr(self, f"_{name}").file = filename
@@ -172,7 +170,7 @@ def generate_sub_catalogue(
     registration_function: Callable,
     units: VelociraptorUnits,
     field_metadata: List[VelociraptorFieldMetadata],
-    mask: Union[None, NDArray[bool], int] = None
+    mask: Union[EllipsisType, NDArray[bool], int] = Ellipsis
 ):
     """
     Generates a sub-catalogue object with the correct properties set.
@@ -236,7 +234,7 @@ class __VelociraptorSubCatalogue(object):
     # The valid paths contained within
     valid_sub_paths: List[str]
 
-    def __init__(self, filename, mask=None):
+    def __init__(self, filename, mask=Ellipsis):
         self.filename = filename
         self.mask = mask
 
@@ -263,7 +261,7 @@ class VelociraptorCatalogue(object):
         filename: str,
         disregard_units: bool = False,
         extra_registration_functions: Union[None, Dict[str, Callable]] = None,
-        mask: Union[None, NDArray[bool], int] = None,
+        mask: Union[EllipsisType, NDArray[bool], int] = Ellipsis,
     ):
         """
         Initialise the velociraptor catalogue with all of the available
@@ -291,10 +289,10 @@ class VelociraptorCatalogue(object):
             conform to the registration function API. This is an advanced
             feature.
 
-        mask: Union[None, NDArray[bool], int], optional
+        mask: Union[EllipsisType, NDArray[bool], int], optional
             If a boolean array is provided, it is used to mask all catalogue
             arrays. If an int is provided, catalogue arrays are masked to the
-            single corresponding element.
+            single corresponding element. Default: Ellipsis (``...``).
         """
         self.filename = filename
         self.disregard_units = disregard_units

--- a/velociraptor/catalogue/catalogue.py
+++ b/velociraptor/catalogue/catalogue.py
@@ -10,9 +10,6 @@ import unyt
 import numpy as np
 
 from typing import Union, Callable, List, Dict
-from numpy.typing import NDArray
-# from types import EllipsisType  # requires python 3.10+
-import builtins  # use 'builtins.ellipsis' instead
 
 from velociraptor.units import VelociraptorUnits
 from velociraptor.catalogue.derived import DerivedQuantities
@@ -171,7 +168,7 @@ def generate_sub_catalogue(
     registration_function: Callable,
     units: VelociraptorUnits,
     field_metadata: List[VelociraptorFieldMetadata],
-    mask: Union['builtins.ellipsis', NDArray[bool], int] = Ellipsis
+    mask: slice = Ellipsis
 ):
     """
     Generates a sub-catalogue object with the correct properties set.
@@ -262,7 +259,7 @@ class VelociraptorCatalogue(object):
         filename: str,
         disregard_units: bool = False,
         extra_registration_functions: Union[None, Dict[str, Callable]] = None,
-        mask: Union['builtins.ellipsis', NDArray[bool], int] = Ellipsis,
+        mask: slice = Ellipsis,
     ):
         """
         Initialise the velociraptor catalogue with all of the available
@@ -290,7 +287,7 @@ class VelociraptorCatalogue(object):
             conform to the registration function API. This is an advanced
             feature.
 
-        mask: Union['builtins.ellipsis', NDArray[bool], int], optional
+        mask: slice, optional
             If a boolean array is provided, it is used to mask all catalogue
             arrays. If an int is provided, catalogue arrays are masked to the
             single corresponding element. Default: Ellipsis (``...``).

--- a/velociraptor/catalogue/catalogue.py
+++ b/velociraptor/catalogue/catalogue.py
@@ -9,9 +9,10 @@ import unyt
 
 import numpy as np
 
-from types import EllipsisType
-from typing import Union, Callable, List, Dict
+from typing import Type, Union, Callable, List, Dict
 from numpy.typing import NDArray
+# from types import EllipsisType  # requires python 3.10+
+import builtins  # use 'builtins.ellipsis' instead
 
 from velociraptor.units import VelociraptorUnits
 from velociraptor.catalogue.derived import DerivedQuantities
@@ -170,7 +171,7 @@ def generate_sub_catalogue(
     registration_function: Callable,
     units: VelociraptorUnits,
     field_metadata: List[VelociraptorFieldMetadata],
-    mask: Union[EllipsisType, NDArray[bool], int] = Ellipsis
+    mask: Union['builtins.ellipsis', NDArray[bool], int] = Ellipsis
 ):
     """
     Generates a sub-catalogue object with the correct properties set.
@@ -261,7 +262,7 @@ class VelociraptorCatalogue(object):
         filename: str,
         disregard_units: bool = False,
         extra_registration_functions: Union[None, Dict[str, Callable]] = None,
-        mask: Union[EllipsisType, NDArray[bool], int] = Ellipsis,
+        mask: Union['builtins.ellipsis', NDArray[bool], int] = Ellipsis,
     ):
         """
         Initialise the velociraptor catalogue with all of the available
@@ -289,7 +290,7 @@ class VelociraptorCatalogue(object):
             conform to the registration function API. This is an advanced
             feature.
 
-        mask: Union[EllipsisType, NDArray[bool], int], optional
+        mask: Union['builtins.ellipsis', NDArray[bool], int], optional
             If a boolean array is provided, it is used to mask all catalogue
             arrays. If an int is provided, catalogue arrays are masked to the
             single corresponding element. Default: Ellipsis (``...``).

--- a/velociraptor/particles/particles.py
+++ b/velociraptor/particles/particles.py
@@ -57,6 +57,9 @@ class VelociraptorGroups(object):
         halo.
         """
 
+        if catalogue.mask is not Ellipsis:
+            raise ValueError('VelociraptorGroups not compatible with masked catalogue.')
+        
         self.filename = filename
         self.catalogue = catalogue
 


### PR DESCRIPTION
A mask can be provided to a `VelociraptorCatalogue` on initialisation (also via `load`). The default is `Ellipsis` (`...`), resulting in the previous behaviour. If another mask is provided, it is applied while reading arrays from the catalogue and reads only the masked region. This can be used e.g. to efficiently load values for a single halo of interest.

The package under development at https://github.com/kyleaoman/swiftgalaxy will depend on this feature.