### PR TITLE
Box size correction

### DIFF
--- a/velociraptor-compute-box-size-correction
+++ b/velociraptor-compute-box-size-correction
@@ -104,8 +104,8 @@ if log_y:
 small_spline = interpol.InterpolatedUnivariateSpline(small_box_x, small_box_y)
 large_spline = interpol.InterpolatedUnivariateSpline(large_box_x, large_box_y)
 
-xmin = min(small_box_x.min(), large_box_x.min())
-xmax = max(small_box_x.max(), large_box_x.max())
+xmin = max(small_box_x.min(), large_box_x.min())
+xmax = min(small_box_x.max(), large_box_x.max())
 x_range = np.linspace(xmin, xmax, 100)
 small_y_range = small_spline(x_range)
 large_y_range = large_spline(x_range)
@@ -120,6 +120,8 @@ correction_data = {}
 correction_data["plot_name"] = args.plotname
 correction_data["plot_type"] = args.plottype
 correction_data["is_log_x"] = True
+correction_data["x_units"] = small_box_plot_data["centers_units"]
+correction_data["x_limits"] = np.array([xmin, xmax]).tolist()
 correction_data["x"] = x_range.tolist()
 correction_data["y"] = correction.tolist()
 with open(output_file, "w") as handle:

--- a/velociraptor-compute-box-size-correction
+++ b/velociraptor-compute-box-size-correction
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+"""
+Compute a box size correction file that can be used as the 'box_size_correction'
+argument for an autoplotter plot.
+
+Usage:
+  velociraptor-compute-box-size-correction \
+    smallbox largebox plotname plottype output
+
+with:
+  - smallbox/largebox: data*.yml output file from a pipeline run
+  - plotname: Name of a particular plot in the data*.yml files
+  - plottype: Type of plot (currently supported: mass_function)
+  - output: Name of an output .yml file. If the .yml extension is missing, it is
+    added.
+"""
+
+import argparse
+import os
+import yaml
+import numpy as np
+import scipy.interpolate as interpol
+
+argparser = argparse.ArgumentParser("Compute the box size correction for a plot.")
+argparser.add_argument(
+    "smallbox", help="Pipeline output for the small box that needs to be corrected."
+)
+argparser.add_argument(
+    "largebox", help="Pipeline output for the large box that we want to correct to."
+)
+argparser.add_argument("plotname", help="Name of the plot that we want to correct.")
+argparser.add_argument("plottype", help="Type of the plot we want to correct.")
+argparser.add_argument(
+    "output", help="Name of the output file that will store the correction."
+)
+args = argparser.parse_args()
+
+if not args.plottype in ["mass_function"]:
+    raise AttributeError(
+        f"Cannot compute box size correction for plot type {args.plottype}!"
+    )
+
+log_x = False
+log_y = False
+if args.plottype in ["mass_function"]:
+    log_x = True
+    log_y = True
+
+small_box = args.smallbox
+large_box = args.largebox
+for file in [args.smallbox, args.largebox]:
+    if not os.path.exists(file):
+        raise AttributeError(f"File {file} could not be found!")
+
+output_file = args.output
+if not output_file.endswith(".yml"):
+    output_file += ".yml"
+try:
+    open(output_file, "w").close()
+except:
+    raise AttributeError(f"Can not write to {output_file}!")
+
+with open(args.smallbox, "r") as handle:
+    small_box = yaml.safe_load(handle)
+with open(args.largebox, "r") as handle:
+    large_box = yaml.safe_load(handle)
+
+try:
+    small_box_data = small_box[args.plotname]["lines"]
+except:
+    raise AttributeError(f"Could not find {args.plotname} in {args.smallbox}!")
+try:
+    large_box_data = large_box[args.plotname]["lines"]
+except:
+    raise AttributeError(f"Could not find {args.plotname} in {args.largebox}!")
+
+try:
+    small_box_plot_data = small_box_data[args.plottype]
+except:
+    raise AttributeError(
+        f"{args.plottype} not found in plot {args.plotname} in {args.smallbox}!"
+    )
+try:
+    large_box_plot_data = large_box_data[args.plottype]
+except:
+    raise AttributeError(
+        f"{args.plottype} not found in plot {args.plotname} in {args.largebox}!"
+    )
+
+small_box_x = small_box_plot_data["centers"]
+small_box_y = small_box_plot_data["values"]
+large_box_x = large_box_plot_data["centers"]
+large_box_y = large_box_plot_data["values"]
+
+if log_x:
+    small_box_x = np.log10(small_box_x)
+    large_box_x = np.log10(large_box_x)
+
+if log_y:
+    small_box_y = np.log10(small_box_y)
+    large_box_y = np.log10(large_box_y)
+
+small_spline = interpol.InterpolatedUnivariateSpline(small_box_x, small_box_y)
+large_spline = interpol.InterpolatedUnivariateSpline(large_box_x, large_box_y)
+
+xmin = min(small_box_x.min(), large_box_x.min())
+xmax = max(small_box_x.max(), large_box_x.max())
+x_range = np.linspace(xmin, xmax, 100)
+small_y_range = small_spline(x_range)
+large_y_range = large_spline(x_range)
+
+if log_y:
+    small_y_range = 10.0**small_y_range
+    large_y_range = 10.0**large_y_range
+
+correction = large_y_range / small_y_range
+
+correction_data = {}
+correction_data["plot_name"] = args.plotname
+correction_data["plot_type"] = args.plottype
+correction_data["is_log_x"] = True
+correction_data["x"] = x_range.tolist()
+correction_data["y"] = correction.tolist()
+with open(output_file, "w") as handle:
+    yaml.safe_dump(correction_data, handle)

--- a/velociraptor/autoplotter/box_size_correction.py
+++ b/velociraptor/autoplotter/box_size_correction.py
@@ -30,4 +30,7 @@ class VelociraptorBoxSizeCorrection:
         else:
             correction = self.correction_spline(bin_centers)
 
-        return bin_centers, mass_function * correction, error
+        corrected_mass_function = mass_function * correction
+        corrected_mass_function.name = mass_function.name
+
+        return bin_centers, corrected_mass_function, error

--- a/velociraptor/autoplotter/box_size_correction.py
+++ b/velociraptor/autoplotter/box_size_correction.py
@@ -1,0 +1,34 @@
+"""
+Functionality to apply a mass dependent correction to quantities that have been
+binned in mass bins (e.g. a mass function).
+"""
+
+import numpy as np
+import yaml
+import os
+import numpy as np
+import scipy.interpolate as interpol
+
+
+class VelociraptorBoxSizeCorrection:
+    def __init__(self, filename: str, correction_directory: str):
+        correction_file = f"{correction_directory}/{filename}"
+        if not os.path.exists(correction_file):
+            raise FileNotFoundError(f"Could not find {correction_file}!")
+        with open(correction_file, "r") as handle:
+            correction_data = yaml.safe_load(handle)
+        self.is_log_x = correction_data["is_log_x"]
+        x = np.array(correction_data["x"])
+        y = np.array(correction_data["y"])
+        self.correction_spline = interpol.InterpolatedUnivariateSpline(x, y)
+
+    def apply_mass_function_correction(self, mass_function_output):
+
+        bin_centers, mass_function, error = mass_function_output
+
+        if self.is_log_x:
+            correction = self.correction_spline(np.log10(bin_centers))
+        else:
+            correction = self.correction_spline(bin_centers)
+
+        return bin_centers, mass_function * correction, error

--- a/velociraptor/autoplotter/box_size_correction.py
+++ b/velociraptor/autoplotter/box_size_correction.py
@@ -6,7 +6,6 @@ binned in mass bins (e.g. a mass function).
 import numpy as np
 import yaml
 import os
-import numpy as np
 import scipy.interpolate as interpol
 
 

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -323,6 +323,10 @@ class VelociraptorLine(object):
                 box_volume=box_volume,
                 return_bin_edges=True,
             )
+            if self.box_size_correction is not None:
+                mass_function_output = self.box_size_correction.apply_mass_function_correction(
+                    mass_function_output
+                )
             self.output = (
                 *mass_function_output,
                 unyt_array([], units=mass_function_output[0].units),

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -275,7 +275,7 @@ class VelociraptorLine(object):
             mass_function_output = create_mass_function_given_bins(
                 masked_x, self.bins, box_volume=box_volume
             )
-            if not self.box_size_correction is None:
+            if self.box_size_correction is not None:
                 mass_function_output = self.box_size_correction.apply_mass_function_correction(
                     mass_function_output
                 )

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -89,6 +89,7 @@ class VelociraptorPlot(object):
     structure_mask: Union[None, array]
     selection_mask: Union[None, array]
     # Apply a box size correction to the plot?
+    correction_directory: str
     box_size_correction: Union[None, VelociraptorBoxSizeCorrection]
     # Where should the legend and z, a information be placed?
     legend_loc: str
@@ -106,6 +107,7 @@ class VelociraptorPlot(object):
         filename: str,
         data: Dict[str, Union[Dict, str]],
         observational_data_directory: str,
+        correction_directory: str,
     ):
         """
         Initialise the plot object variables.
@@ -113,6 +115,7 @@ class VelociraptorPlot(object):
         self.filename = filename
         self.data = data
         self.observational_data_directory = observational_data_directory
+        self.correction_directory = correction_directory
 
         self._parse_data()
 
@@ -529,7 +532,7 @@ class VelociraptorPlot(object):
         try:
             box_size_correction = str(self.data["box_size_correction"])
             self.box_size_correction = VelociraptorBoxSizeCorrection(
-                box_size_correction
+                box_size_correction, self.correction_directory
             )
         except:
             self.box_size_correction = None
@@ -564,7 +567,7 @@ class VelociraptorPlot(object):
         try:
             box_size_correction = str(self.data["box_size_correction"])
             self.box_size_correction = VelociraptorBoxSizeCorrection(
-                box_size_correction
+                box_size_correction, self.correction_directory
             )
         except:
             self.box_size_correction = None
@@ -1061,6 +1064,8 @@ class AutoPlotter(object):
     plots: List[VelociraptorPlot]
     # Directory containing the observational data.
     observational_data_directory: str
+    # Directory containing box size correction data
+    correction_directory: str
     # Whether or not the plots were created successfully.
     created_successfully: List[bool]
     # global mask
@@ -1070,6 +1075,7 @@ class AutoPlotter(object):
         self,
         filename: Union[str, List[str]],
         observational_data_directory: Union[None, str] = None,
+        correction_directory: Union[None, str] = None,
     ) -> None:
         """
         Initialises the AutoPlotter object with the yaml filename(s).
@@ -1093,6 +1099,9 @@ class AutoPlotter(object):
             observational_data_directory
             if observational_data_directory is not None
             else ""
+        )
+        self.correction_directory = Path(
+            correction_directory if correction_directory is not None else ""
         )
 
         self.load_yaml()
@@ -1124,7 +1133,12 @@ class AutoPlotter(object):
         """
 
         self.plots = [
-            VelociraptorPlot(filename, plot, self.observational_data_directory)
+            VelociraptorPlot(
+                filename,
+                plot,
+                self.observational_data_directory,
+                self.correction_directory,
+            )
             for filename, plot in self.yaml.items()
         ]
 

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -534,7 +534,7 @@ class VelociraptorPlot(object):
             self.box_size_correction = VelociraptorBoxSizeCorrection(
                 box_size_correction, self.correction_directory
             )
-        except:
+        except KeyError:
             self.box_size_correction = None
         # A bit of a hacky workaround - improve this in the future
         # by combining this functionality properly into the
@@ -569,7 +569,7 @@ class VelociraptorPlot(object):
             self.box_size_correction = VelociraptorBoxSizeCorrection(
                 box_size_correction, self.correction_directory
             )
-        except:
+        except KeyError:
             self.box_size_correction = None
         # A bit of a hacky workaround - improve this in the future
         # by combining this functionality properly into the

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -4,6 +4,7 @@ Main objects for holding information relating to the autoplotter.
 
 from velociraptor import VelociraptorCatalogue
 from velociraptor.autoplotter.lines import VelociraptorLine, valid_line_types
+from velociraptor.autoplotter.box_size_correction import VelociraptorBoxSizeCorrection
 from velociraptor.exceptions import AutoPlotterError
 from velociraptor.observations import load_observations
 
@@ -87,6 +88,8 @@ class VelociraptorPlot(object):
     exclude_structure_type: Union[None, int]
     structure_mask: Union[None, array]
     selection_mask: Union[None, array]
+    # Apply a box size correction to the plot?
+    box_size_correction: Union[None, VelociraptorBoxSizeCorrection]
     # Where should the legend and z, a information be placed?
     legend_loc: str
     redshift_loc: str
@@ -523,6 +526,13 @@ class VelociraptorPlot(object):
 
         self._parse_common_histogramtype()
 
+        try:
+            box_size_correction = str(self.data["box_size_correction"])
+            self.box_size_correction = VelociraptorBoxSizeCorrection(
+                box_size_correction
+            )
+        except:
+            self.box_size_correction = None
         # A bit of a hacky workaround - improve this in the future
         # by combining this functionality properly into the
         # VelociraptorLine methods.
@@ -535,6 +545,7 @@ class VelociraptorPlot(object):
                 start=dict(value=self.x_lim[0].value, units=self.x_lim[0].units),
                 end=dict(value=self.x_lim[1].value, units=self.x_lim[1].units),
             ),
+            box_size_correction=self.box_size_correction,
         )
 
         return
@@ -550,6 +561,13 @@ class VelociraptorPlot(object):
 
         self._parse_common_histogramtype()
 
+        try:
+            box_size_correction = str(self.data["box_size_correction"])
+            self.box_size_correction = VelociraptorBoxSizeCorrection(
+                box_size_correction
+            )
+        except:
+            self.box_size_correction = None
         # A bit of a hacky workaround - improve this in the future
         # by combining this functionality properly into the
         # VelociraptorLine methods.
@@ -563,6 +581,7 @@ class VelociraptorPlot(object):
                 end=dict(value=self.x_lim[1].value, units=self.x_lim[1].units),
                 adaptive=True,
             ),
+            box_size_correction=self.box_size_correction,
         )
 
         return


### PR DESCRIPTION
First draft of a new mechanism to add a correction to catalogue values in pipeline plots to correct for box size effects.

The idea is that the user specifies an additional `box_size_correction` argument in the autoplotter config file, which points to a file that contains correction values (format still to be decided). This is then used to initialise an object that has a correction function that is applied to the plot data before it is plotted.

@EvgeniiChaikin I will expand on this tomorrow, but this is what I had in mind.