### PR TITLE
Filter out NaN values when computing lines

### DIFF
--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -243,6 +243,15 @@ class VelociraptorLine(object):
         masked_x = x
         masked_y = y
 
+        # filter out NaN values to prevent crashes if all x values are NaN
+        if masked_y is not None:
+            mask = isnan(x) | isnan(y)
+            masked_x = masked_x[~mask]
+            masked_y = masked_y[~mask]
+        else:
+            mask = isnan(x)
+            masked_x = masked_x[~mask]
+
         if self.lower is not None:
             self.lower.convert_to_units(y.units)
             mask = masked_y > self.lower


### PR DESCRIPTION
`unyt.matplotlib_support` seems to be unable to deal with plots where all data values are `NaN`. You can end up in that scenario when you compute a log median line for data that only has `NaN` or `0` x values (which apparently really happens for some of the pipeline plots).

The solution is to filter out all `NaN` values before computing the median line (or any other line for that matter).

@james-trayford could you check that this fixes your issue and does not break any of the plots in the pipeline?