### PR TITLE
Include the SNIa rates inside the aperatures in the library

### DIFF
--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1522,6 +1522,7 @@ def registration_element_masses_in_stars(
 
     return
 
+
 def registration_snia_rates(
     field_path: str, unit_system: VelociraptorUnits
 ) -> (unyt.Unit, str, str):
@@ -1529,7 +1530,7 @@ def registration_snia_rates(
     Registers the SNIa rates within apertures
     """
 
-    unit = unit_system.velocity/unit_system.length
+    unit = unit_system.velocity / unit_system.length
     # Capture aperture size
     match_string = "Aperture_SNIaRates_aperture_total_star_([0-9]*)_kpc"
     regex = cached_regex(match_string)
@@ -1545,6 +1546,7 @@ def registration_snia_rates(
         return unit, full_name, snake_case
     else:
         raise RegistrationDoesNotMatchError
+
 
 # TODO
 # lambda_B

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1529,7 +1529,7 @@ def registration_snia_rates(
     Registers the SNIa rates within apertures
     """
 
-    unit = unit_system.length/unit_system.velocity
+    unit = unit_system.velocity/unit_system.length
     # Capture aperture size
     match_string = "Aperture_SNIaRates_aperture_total_star_([0-9]*)_kpc"
     regex = cached_regex(match_string)
@@ -1537,7 +1537,6 @@ def registration_snia_rates(
     match = regex.match(field_path)
 
     if match:
-        #long_species = match.group(1)
         aperture_size = match.group(1)
 
         full_name = f"SNIa rate ({aperture_size} [# $\\rm yr^{-1}$])"

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1522,6 +1522,31 @@ def registration_element_masses_in_stars(
 
     return
 
+def registration_snia_rates(
+    field_path: str, unit_system: VelociraptorUnits
+) -> (unyt.Unit, str, str):
+    """
+    Registers the SNIa rates within apertures
+    """
+
+    unit = 1/unit_system.time
+
+    # Capture aperture size
+    match_string = "Aperture_SNIaRates_aperture_total_gas_([0-9]*)_kpc"
+    regex = cached_regex(match_string)
+
+    match = regex.match(field_path)
+
+    if match:
+        long_species = match.group(1)
+        aperture_size = match.group(2)
+
+        full_name = f"SNIa rate ({aperture_size} [# $\\rm yr^{-1}$])"
+        snake_case = f"snia_rates_{aperture_size}_p_yr"
+
+        return unit, full_name, snake_case
+    else:
+        raise RegistrationDoesNotMatchError
 
 # TODO
 # lambda_B
@@ -1545,6 +1570,7 @@ def registration_element_masses_in_stars(
 global_registration_functions = {
     k: globals()[f"registration_{k}"]
     for k in [
+        "snia_rates",
         "metallicity",
         "ids",
         "energies",

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1537,8 +1537,8 @@ def registration_snia_rates(
     match = regex.match(field_path)
 
     if match:
-        long_species = match.group(1)
-        aperture_size = match.group(2)
+        #long_species = match.group(1)
+        aperture_size = match.group(1)
 
         full_name = f"SNIa rate ({aperture_size} [# $\\rm yr^{-1}$])"
         snake_case = f"snia_rates_{aperture_size}_p_yr"

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1539,8 +1539,8 @@ def registration_snia_rates(
     if match:
         aperture_size = match.group(1)
 
-        full_name = f"SNIa rate ({aperture_size} [# $\\rm yr^{-1}$])"
-        snake_case = f"snia_rates_{aperture_size}_p_yr"
+        full_name = f"SNIa rate ({aperture_size} kpc)"
+        snake_case = f"snia_rates_{aperture_size}_kpc"
 
         return unit, full_name, snake_case
     else:

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1531,7 +1531,7 @@ def registration_snia_rates(
 
     unit = unit_system.length/unit_system.velocity
     # Capture aperture size
-    match_string = "Aperture_SNIaRates_aperture_total_gas_([0-9]*)_kpc"
+    match_string = "Aperture_SNIaRates_aperture_total_star_([0-9]*)_kpc"
     regex = cached_regex(match_string)
 
     match = regex.match(field_path)

--- a/velociraptor/catalogue/registration.py
+++ b/velociraptor/catalogue/registration.py
@@ -1529,8 +1529,7 @@ def registration_snia_rates(
     Registers the SNIa rates within apertures
     """
 
-    unit = 1/unit_system.time
-
+    unit = unit_system.length/unit_system.velocity
     # Capture aperture size
     match_string = "Aperture_SNIaRates_aperture_total_gas_([0-9]*)_kpc"
     regex = cached_regex(match_string)


### PR DESCRIPTION
Based on the title, this is just a merge request to also include the SNIa rates in the velociraptor library. So far they were not included, this fixes that. 