### PR TITLE
Move the creation of plt.figure ouside the x vs. y scatter method

### DIFF
--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -13,7 +13,7 @@ import velociraptor.autoplotter.plot as plot
 from unyt import unyt_quantity, unyt_array, matplotlib_support
 from unyt.exceptions import UnitConversionError
 from numpy import log10, linspace, logspace, array, logical_and, ones
-from matplotlib.pyplot import Axes, Figure, close
+from matplotlib.pyplot import Axes, Figure, close, subplots
 from yaml import safe_load
 from typing import Union, List, Dict, Tuple
 from pathlib import Path
@@ -829,7 +829,8 @@ class VelociraptorPlot(object):
         y = self.get_quantity_from_catalogue_with_mask(self.y, catalogue)
         y.convert_to_units(self.y_units)
 
-        fig, ax = plot.scatter_x_against_y(x, y)
+        fig, ax = subplots()
+        plot.scatter_x_against_y(x, y, ax)
         self._add_lines_to_axes(ax=ax, x=x, y=y)
 
         return fig, ax

--- a/velociraptor/autoplotter/objects.py
+++ b/velociraptor/autoplotter/objects.py
@@ -830,7 +830,7 @@ class VelociraptorPlot(object):
         y.convert_to_units(self.y_units)
 
         fig, ax = subplots()
-        plot.scatter_x_against_y(x, y, ax)
+        plot.scatter_x_against_y(ax=ax, x=x, y=y)
         self._add_lines_to_axes(ax=ax, x=x, y=y)
 
         return fig, ax

--- a/velociraptor/autoplotter/plot.py
+++ b/velociraptor/autoplotter/plot.py
@@ -16,9 +16,9 @@ from typing import Tuple, Union
 import velociraptor.tools as tools
 
 
-def scatter_x_against_y(x: unyt.unyt_array, y: unyt.unyt_array, ax: plt.Axes) -> None:
+def scatter_x_against_y(ax: plt.Axes, x: unyt.unyt_array, y: unyt.unyt_array) -> None:
     """
-    Creates a scatter of x against y (unyt arrays).
+    Plots a scatter of x against y (unyt arrays).
     """
 
     kwargs = dict(edgecolor="none", zorder=-100)

--- a/velociraptor/autoplotter/plot.py
+++ b/velociraptor/autoplotter/plot.py
@@ -16,14 +16,10 @@ from typing import Tuple, Union
 import velociraptor.tools as tools
 
 
-def scatter_x_against_y(
-    x: unyt.unyt_array, y: unyt.unyt_array
-) -> Tuple[plt.Figure, plt.Axes]:
+def scatter_x_against_y(x: unyt.unyt_array, y: unyt.unyt_array, ax: plt.Axes) -> None:
     """
     Creates a scatter of x against y (unyt arrays).
     """
-
-    fig, ax = plt.subplots()
 
     kwargs = dict(edgecolor="none", zorder=-100)
 
@@ -38,7 +34,7 @@ def scatter_x_against_y(
 
     ax.scatter(x.value, y.value, **kwargs)
 
-    return fig, ax
+    return
 
 
 def histogram_x_against_y(


### PR DESCRIPTION
Move the creation of plt.figure ouside `scatter_x_against_y` method.

- This change was motivated by @FHusko's recent update in the colibre-pipeline (https://github.com/SWIFTSIM/pipeline-configs/pull/214). In that PR, many scripts repeat exactly the same calculations as those carried out by the `scatter_x_against_y` method. However, the `scatter_x_against_y` method in its current version cannot be simply imported and applied to Filip's plots because `scatter_x_against_y` creates its own `(fig,ax)` object.

- This PR makes `scatter_x_against_y` create and apply the scatter to the `(fig,ax)` object passed by the user as an additional function's argument, instead of creating a new `(fig,ax)`  object.

- With this update, not only the `scatter_x_against_y` method becomes compatible with Filip's scripts, but also in general it should be better if the `scatter_x_against_y` method does only one action: plotting (instead of creating a figure **and** plotting).