### PR TITLE
Fix typo in the name of matplotlib library's rasterize parameter

### DIFF
--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -640,7 +640,7 @@ class ObservationalData(object):
                 kwargs["markerfacecolor"] = "none"
 
             if len(self.x) > 1000:
-                kwargs["rasterize"] = True
+                kwargs["rasterized"] = True
         elif self.plot_as == "line":
             kwargs["zorder"] = line_zorder
 


### PR DESCRIPTION
See https://matplotlib.org/stable/api/_as_gen/matplotlib.artist.Artist.set_rasterized.html#matplotlib.artist.Artist.set_rasterized for documentation on the correct parameter name.

Without this fix, the branch from PR https://github.com/SWIFTSIM/pipeline-configs/pull/239 will crash.