### PR TITLE
Weaken dependency on swiftsimio

### DIFF
--- a/velociraptor/__init__.py
+++ b/velociraptor/__init__.py
@@ -28,8 +28,6 @@ except RuntimeError:
 
 
 from velociraptor.catalogue.catalogue import Catalogue, CatalogueTypeError
-from velociraptor.catalogue.velociraptor_catalogue import VelociraptorCatalogue
-from velociraptor.catalogue.soap_catalogue import SOAPCatalogue
 from velociraptor.__version__ import __version__
 
 from typing import Union, List
@@ -77,6 +75,8 @@ def load(
     Catalogue
         The Catalogue object that describes your .properties file.
     """
+    from velociraptor.catalogue.velociraptor_catalogue import VelociraptorCatalogue
+    from velociraptor.catalogue.soap_catalogue import SOAPCatalogue
 
     try:
         catalogue = VelociraptorCatalogue(


### PR DESCRIPTION
In `velociraptor-comparison-data`, we are currently facing the problem that without introducing a dependency on the `swiftsimio` library, the conversion scripts do not work.  Since converting raw data to hdf5 format does not need to know anything about `swiftsimio`, the error seems rather surprising.

The error occurs because the implementation of the SOAP catalogue in the `velociraptor-python` library allows usage of swift's most generic cosmology, and the class that handles this most generic cosmology is imported from the `swiftsimio` library (https://github.com/SWIFTSIM/velociraptor-python/blob/master/velociraptor/catalogue/soap_catalogue.py#L15)

The question is then: why is this even a problem if in `velociraptor-comparison-data` we never use SOAP catalogues directly? 

The answer is that in `velociraptor-comparison-data`, we do the following import

` from velociraptor.observations.object import ObservationalData,`

and when this happens, python needs to initialise each `velociraptor-python`'s submodule in the hierarchy, which is done by calling the corresponding `__init__.py` files. The `__init__.py` file of the `velociraptor` submodule contains the line

`from velociraptor.catalogue.soap_catalogue import SOAPCatalogue,`

which imports the SOAP catalogue class leading to the dependency on the `swiftsimio` library, and, hence, the error described above.

The error looks as follows:

![232315242-dba86b55-4c79-46fb-bb12-87fc7052cef6](https://user-images.githubusercontent.com/20153933/236071609-738da911-8d5a-43ad-b846-8c3dd94a9645.png)

To resolve the error without introducing the dependency of `velociraptor-comparison-data` on `swiftsimio`, in this PR I propose an easy change: just take the two lines with imports of SOAP and Velociraptor catalogues from the top of the `__init__.py` file and move them inside the `load` function. This way the catalogues will only be touched during the actual loading of the data (when the `load` function is used), while simply calling `__init__.py` when initialising the submodule will not do anything.

