### PR TITLE
Register StellarBirthTemperature properties

### DIFF
--- a/velociraptor/catalogue/translator.py
+++ b/velociraptor/catalogue/translator.py
@@ -1222,6 +1222,18 @@ def VR_to_SOAP(particle_property_name: str) -> str:
             "exclusivesphere.100kpc.gasmassincolddensegas",
             -1,
         ),
+        "stellar_birth_temperatures.logaverage": (
+            "fofsubhaloproperties.logarithmicallyaveragedstellarbirthtemperature",
+            -1,
+        ),
+        "stellar_birth_temperatures.min": (
+            "fofsubhaloproperties.minimumstellarbirthtemperature",
+            -1,
+        ),
+        "stellar_birth_temperatures.max": (
+            "fofsubhaloproperties.maximumstellarbirthtemperature",
+            -1,
+        ),
         "stellar_birth_densities.logaverage": (
             "fofsubhaloproperties.logarithmicallyaveragedstellarbirthdensity",
             -1,


### PR DESCRIPTION
https://github.com/SWIFTSIM/SOAP/pull/61 adds StellarBirthTemperature properties. We need to register them for use in the plotting pipeline.