### PR TITLE
Update stellar birth properties in SOAP translator file

### DIFF
--- a/velociraptor/catalogue/translator.py
+++ b/velociraptor/catalogue/translator.py
@@ -1222,8 +1222,8 @@ def VR_to_SOAP(particle_property_name: str) -> str:
             "exclusivesphere.100kpc.gasmassincolddensegas",
             -1,
         ),
-        "stellar_birth_densities.logaverage": (
-            "fofsubhaloproperties.logarithmicallyaveragedstellarbirthdensity",
+        "stellar_birth_densities.median": (
+            "fofsubhaloproperties.medianstellarbirthdensity",
             -1,
         ),
         "stellar_birth_densities.min": (
@@ -1234,8 +1234,20 @@ def VR_to_SOAP(particle_property_name: str) -> str:
             "fofsubhaloproperties.maximumstellarbirthdensity",
             -1,
         ),
-        "stellar_birth_temperatures.logaverage": (
-            "fofsubhaloproperties.logarithmicallyaveragedstellarbirthtemperature",
+        "stellar_birth_pressures.median": (
+            "fofsubhaloproperties.medianstellarbirthpressure",
+            -1,
+        ),
+        "stellar_birth_pressures.min": (
+            "fofsubhaloproperties.minimumstellarbirthpressure",
+            -1,
+        ),
+        "stellar_birth_pressures.max": (
+            "fofsubhaloproperties.maximumstellarbirthpressure",
+            -1,
+        ),
+        "stellar_birth_temperatures.median": (
+            "fofsubhaloproperties.medianstellarbirthtemperature",
             -1,
         ),
         "stellar_birth_temperatures.min": (


### PR DESCRIPTION
- Add stellar birth pressures to the SOAP translator file
- Inside the translator file, replace `average-of-log` with `median` for all stellar birth properties

Follows https://github.com/SWIFTSIM/SOAP/pull/62