### PR TITLE
Functionality to display lower and upper limits of observational data

### DIFF
--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -179,7 +179,7 @@ class ObservationalData(object):
     y_description: str
         Default label for horizontal axis (without units), also a
         description of the variable.
-from numpy import sum as np_sum
+
     filename: str
         Filename that the data was read from, or was written to.
 

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -329,13 +329,6 @@ class ObservationalData(object):
         except KeyError:
             self.upper_limits = None
 
-        try:
-            self.y_scatter = unyt_array.from_hdf5(
-                filename, dataset_name=f"{prefix}scatter", group_name="y"
-            )
-        except KeyError:
-            self.y_scatter = None
-
         with h5py.File(filename, "r") as handle:
             metadata = handle[f"{prefix}metadata"].attrs
 

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -9,7 +9,6 @@ and reading files.
 
 from unyt import unyt_quantity, unyt_array
 from numpy import tanh, log10, logical_and
-from numpy import sum as np_sum
 from matplotlib.pyplot import Axes
 from matplotlib import rcParams
 
@@ -180,7 +179,7 @@ class ObservationalData(object):
     y_description: str
         Default label for horizontal axis (without units), also a
         description of the variable.
-
+from numpy import sum as np_sum
     filename: str
         Filename that the data was read from, or was written to.
 
@@ -231,8 +230,8 @@ class ObservationalData(object):
     x_scatter: Union[unyt_array, None]
     y_scatter: Union[unyt_array, None]
     # are y data points upper/lower limits?
-    lower_limits: Union[unyt_array[bool], None]
-    upper_limits: Union[unyt_array[bool], None]
+    lower_limits: Union[unyt_array, None]
+    upper_limits: Union[unyt_array, None]
     # x and y are comoving?
     x_comoving: bool
     y_comoving: bool
@@ -478,8 +477,8 @@ class ObservationalData(object):
         scatter: Union[unyt_array, None],
         comoving: bool,
         description: str,
-        lolims: Union[unyt_array[bool], None] = None,
-        uplims: Union[unyt_array[bool], None] = None,
+        lolims: Union[unyt_array, None] = None,
+        uplims: Union[unyt_array, None] = None,
     ):
         """
         Associate an y quantity with this observational data instance.
@@ -501,12 +500,12 @@ class ObservationalData(object):
             Short description of the data, e.g. Stellar Masses
 
         lolims: Union[unyt_array[bool], None]
-            A bool unyt_array indicating whether the y values are lower limits.
-            The default is `no'.
+           A bool unyt_array indicating whether the y values are lower limits.
+           The default is None, meaning no data point is a lower limit.
 
         uplims: Union[unyt_array[bool], None]
             A bool unyt_array indicating whether the y values are upper limits.
-            The default is `no'.
+            The default is None, meaning no data point is an upper limit.
         """
 
         self.y = array

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -492,11 +492,11 @@ class ObservationalData(object):
         description: str
             Short description of the data, e.g. Stellar Masses
 
-        lolims: Union[unyt_array[bool], None]
+        lolims: Union[unyt_array, None]
            A bool unyt_array indicating whether the y values are lower limits.
            The default is None, meaning no data point is a lower limit.
 
-        uplims: Union[unyt_array[bool], None]
+        uplims: Union[unyt_array, None]
             A bool unyt_array indicating whether the y values are upper limits.
             The default is None, meaning no data point is an upper limit.
         """
@@ -505,13 +505,6 @@ class ObservationalData(object):
         self.y_units = array.units
         self.y_comoving = comoving
         self.y_description = description
-
-        if scatter is not None:
-            self.y_scatter = scatter.to(self.y_units)
-        elif lolims is not None or uplims is not None:
-            self.y_scatter = self.y * 0.0
-        else:
-            self.y_scatter = None
 
         if lolims is not None:
             self.lower_limits = lolims
@@ -524,27 +517,29 @@ class ObservationalData(object):
                         "of 'bool' type and cannot both be 'True' for the same data points."
                     )
 
-            # In the case of upper or lower limits, the scatter values define the size of the arrows
-            lolims_arrow_size = self.y[self.lower_limits.value] / 3.0
-            try:
-                self.y_scatter[self.lower_limits.value] = lolims_arrow_size
-            except IndexError:
-                self.y_scatter[:, self.lower_limits.value] = lolims_arrow_size
-
         else:
             self.lower_limits = None
 
         if uplims is not None:
             self.upper_limits = uplims
-
-            # In the case of upper or lower limits, the scatter values define the size of the arrows
-            uplims_arrow_size = self.y[self.upper_limits.value] / 3.0
-            try:
-                self.y_scatter[self.upper_limits.value] = uplims_arrow_size
-            except IndexError:
-                self.y_scatter[:, self.upper_limits.value] = uplims_arrow_size
         else:
             self.upper_limits = None
+
+        if scatter is not None:
+            self.y_scatter = scatter.to(self.y_units)
+        # In the absence of provided scatter values, set default values to indicate the lower or upper limits
+        elif lolims is not None or uplims is not None:
+            self.y_scatter = self.y * 0.0
+            if lolims is not None:
+                self.y_scatter[self.lower_limits.value] = (
+                    self.y[self.lower_limits.value] / 3.0
+                )
+            if uplims is not None:
+                self.y_scatter[self.upper_limits.value] = (
+                    self.y[self.upper_limits.value] / 3.0
+                )
+        else:
+            self.y_scatter = None
 
         return
 

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -6,7 +6,7 @@ Tools for adding in extra (e.g. observational) data to plots.
 Includes an object container and helper functions for creating
 and reading files.
 """
-
+import numpy as np
 from unyt import unyt_quantity, unyt_array
 from numpy import tanh, log10, logical_and
 from matplotlib.pyplot import Axes
@@ -508,6 +508,8 @@ class ObservationalData(object):
 
         if scatter is not None:
             self.y_scatter = scatter.to(self.y_units)
+        elif lolims is not None or uplims is not None:
+            self.y_scatter = self.y * 0.0
         else:
             self.y_scatter = None
 
@@ -521,11 +523,26 @@ class ObservationalData(object):
                         "Entries of the unyt arrays representing lower and upper limits must be "
                         "of 'bool' type and cannot both be 'True' for the same data points."
                     )
+
+            # In the case of upper or lower limits, the scatter values define the size of the arrows
+            lolims_arrow_size = self.y[self.lower_limits.value] / 3.0
+            try:
+                self.y_scatter[self.lower_limits.value] = lolims_arrow_size
+            except IndexError:
+                self.y_scatter[:, self.lower_limits.value] = lolims_arrow_size
+
         else:
             self.lower_limits = None
 
         if uplims is not None:
             self.upper_limits = uplims
+
+            # In the case of upper or lower limits, the scatter values define the size of the arrows
+            uplims_arrow_size = self.y[self.upper_limits.value] / 3.0
+            try:
+                self.y_scatter[self.upper_limits.value] = uplims_arrow_size
+            except IndexError:
+                self.y_scatter[:, self.upper_limits.value] = uplims_arrow_size
         else:
             self.upper_limits = None
 

--- a/velociraptor/observations/objects.py
+++ b/velociraptor/observations/objects.py
@@ -6,7 +6,7 @@ Tools for adding in extra (e.g. observational) data to plots.
 Includes an object container and helper functions for creating
 and reading files.
 """
-import numpy as np
+
 from unyt import unyt_quantity, unyt_array
 from numpy import tanh, log10, logical_and
 from matplotlib.pyplot import Axes


### PR DESCRIPTION
This PR adds a new functionality that enables the user to indicate lower and/or upper limits of observational data.

To specify lower/upper limits, the user will need to pass one or two bool arrays to the `associate_y()` method in the conversion script that converts the data from raw to hdf5 format.

Once the raw data have been processed and saved as an hdf5 file, no further changes are required. That is: everything else in the pipeline remains the same.

**For example,**

I can modify `data/GalaxyHIMassFunction/convertJones2018.py` conversion script as

```
data = np.genfromtxt(input_filename, comments="#")

processed = ObservationalData()

comment = (
    "Jones et al. (2018). Estimated for ALFALFA survey at z=0"
    f"data, h-corrected for SWIFT using Cosmology: {cosmology.name}."
)

citation = "Jones et al. (2018, ALFALFA)"
bibcode = "2018MNRAS.477....2J"
name = "HI mass function from ALFALFA at z=0"
plot_as = "points"
redshift = 0.0
h = cosmology.h

M = 10 ** data[:, 0] * (h / ORIGINAL_H) ** (-2) * unyt.Solar_Mass
Phi = 10 ** data[:, 1] * (h / ORIGINAL_H) ** 3 * unyt.Mpc ** (-3)

# no error in M_HI provided
M_err = np.row_stack([M.value * 0.0] * 2) * M.units
Phi_err = np.abs(
    (10 ** data[:, [2, 3]] * (h / ORIGINAL_H) ** 3 * unyt.Mpc ** (-3)) - Phi[:, None]
).T

up_lims = np.zeros_like(M) ### THIS IS A NEW LINE
lo_lims = np.zeros_like(M) ###  THIS IS A NEW LINE
up_lims[2] = True # or 1 ### THIS IS A NEW LINE
lo_lims[-3:] = True ###  THIS IS A NEW LINE

processed.associate_x(M, scatter=M_err, comoving=True, description="Galaxy HI Mass")
processed.associate_y(Phi, scatter=Phi_err, comoving=True, description="Phi (HIMF)", uplims=up_lims, lolims=lo_lims) ###  THIS IS A MODIFIED LINE
processed.associate_citation(citation, bibcode)
processed.associate_name(name)
processed.associate_comment(comment)
processed.associate_redshift(redshift)
processed.associate_plot_as(plot_as)
processed.associate_cosmology(cosmology)

output_path = f"{output_directory}/{output_filename}"

if os.path.exists(output_path):
    os.remove(output_path)

processed.write(filename=output_path)
```

then I can use the standard methods to load and plot the processed data as

```
import matplotlib.pylab as plt
from velociraptor.observations import load_observations
data = load_observations("./Jones2018.hdf5")[0]

fig, ax = plt.subplots(1,1)
data.plot_on_axes(ax)
ax.loglog()
plt.savefig("limits.png")

```

The resulting figure is

![limits](https://github.com/SWIFTSIM/velociraptor-python/assets/20153933/9dc9acdf-cb43-41b8-a58e-ad3253f28b30)

Note that if an observational dataset is shown as 'line' as opposed to 'scatter', then lower/upper limits will still be displayed. E.g.

![limits2](https://github.com/SWIFTSIM/velociraptor-python/assets/20153933/d4c916be-463a-4884-be40-d485a92404ae)




