### PR TITLE
Set upper/lower as ceiling/floor

### DIFF
--- a/velociraptor/autoplotter/__init__.py
+++ b/velociraptor/autoplotter/__init__.py
@@ -70,10 +70,10 @@ This yaml file has the following format:
          units: end value units
        # Restriction of binning vertically
        lower:
-         value: lower value for median/mean line
+         value: floor value when computing median/mean line
          units: lower value units
        upper:
-         value: upper value for median/mean line
+         value: ceiling value when computing median/mean line
          units: upper value units
      # Generic metadata for plot
      metadata:

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -252,6 +252,9 @@ class VelociraptorLine(object):
             mask = isnan(x)
             masked_x = masked_x[~mask]
 
+        if (self.lower is not None) and (self.upper is not None):
+            assert self.upper > self.lower
+
         if self.lower is not None:
             self.lower.convert_to_units(y.units)
             mask = masked_y < self.lower

--- a/velociraptor/autoplotter/lines.py
+++ b/velociraptor/autoplotter/lines.py
@@ -254,15 +254,13 @@ class VelociraptorLine(object):
 
         if self.lower is not None:
             self.lower.convert_to_units(y.units)
-            mask = masked_y > self.lower
-            masked_x = masked_x[mask]
-            masked_y = masked_y[mask]
+            mask = masked_y < self.lower
+            masked_y[mask] = self.lower
 
         if self.upper is not None:
             self.upper.convert_to_units(y.units)
-            mask = masked_y < self.upper
-            masked_x = masked_x[mask]
-            masked_y = masked_y[mask]
+            mask = masked_y > self.upper
+            masked_y[mask] = self.upper
 
         if self.median:
             self.output = lines.binned_median_line(


### PR DESCRIPTION
The autoplotter allows for a `lower` value to be passed. Currently this removes all datapoints with values smaller than the value of `lower`. This can lead to incorrect percentiles when calculating medians. This PR instead set the value of `lower` as a floor value.